### PR TITLE
fix(audio): restore transmit on system default microphone input

### DIFF
--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -105,6 +105,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AudioLogger.clear()
         let sdkVersion = String(cString: TT_GetVersion())
         AudioLogger.log("App launched — TeamTalk SDK %@", sdkVersion)
+        #if DEBUG
+        _ = AudioPCMResamplerSelfTest.runAll()
+        #endif
         connectionController.delegate = self
         connectionController.audioDeviceChangeMonitor = audioDeviceChangeMonitor
         UNUserNotificationCenter.current().delegate = self

--- a/App/ttaccessible/Services/AdvancedMicrophoneAudioEngine.swift
+++ b/App/ttaccessible/Services/AdvancedMicrophoneAudioEngine.swift
@@ -87,6 +87,7 @@ final class AdvancedMicrophoneAudioEngine {
     private struct StateSnapshot {
         let configuration: AdvancedMicrophoneAudioConfiguration
         let streamID: Int32
+        let encoderFormat: AdvancedMicrophoneAudioTargetFormat
     }
 
     private let stateLock = NSLock()
@@ -94,8 +95,12 @@ final class AdvancedMicrophoneAudioEngine {
 
     private var engine: AVAudioEngine?
     private var currentConfiguration: AdvancedMicrophoneAudioConfiguration?
+    /// Sample rate/channels expected by TeamTalk encoder (channel codec or preview target).
+    private var encoderOutputFormat: AdvancedMicrophoneAudioTargetFormat?
     private var nextStreamID: Int32 = 1
     private var activeStreamID: Int32 = 0
+    private var consecutiveAECDropCount = 0
+    private let maxConsecutiveAECDrops = 8
 
     /// Mixer node used as the stable tap point.
     private var mixerNode: AVAudioMixerNode?
@@ -172,14 +177,9 @@ final class AdvancedMicrophoneAudioEngine {
             throw AdvancedMicrophoneAudioEngineError.deviceUnavailable
         }
 
-        let defaultDeviceID = Self.systemDefaultInputDeviceID()
-        let isSystemDefault = (deviceID == defaultDeviceID)
-
-        if isSystemDefault {
-            return try startWithAVAudioEngine(configuration: configuration, deviceID: deviceID)
-        } else {
-            return try startWithStandaloneAUHAL(configuration: configuration, deviceID: deviceID)
-        }
+        // Always use AUHAL with an explicit CoreAudio device so system default behaves
+        // the same as named devices (AVAudioEngine was unreliable during TeamTalk transmit).
+        return try startWithStandaloneAUHAL(configuration: configuration, deviceID: deviceID)
     }
 
     // MARK: - AVAudioEngine Path (system default device)
@@ -436,10 +436,17 @@ final class AdvancedMicrophoneAudioEngine {
         let accumTargetFrames = max(Int((sampleRate * Double(tapIntervalMSec)) / 1000.0), 256)
         let accumBufferSize = (accumTargetFrames + Int(maxFrames)) * channelCount
 
+        let encoderFormat = configuration.targetFormat
         let effectiveTargetFormat = AdvancedMicrophoneAudioTargetFormat(
             sampleRate: sampleRate,
-            channels: configuration.targetFormat.channels,
-            txIntervalMSec: configuration.targetFormat.txIntervalMSec
+            channels: encoderFormat.channels,
+            txIntervalMSec: encoderFormat.txIntervalMSec
+        )
+
+        AudioCaptureDiagnostics.shared.resetForNewCapture(
+            path: "AUHAL",
+            captureRate: Int(sampleRate.rounded()),
+            outputRate: Int(encoderFormat.sampleRate.rounded())
         )
 
         // Store state before setting callback.
@@ -457,6 +464,8 @@ final class AdvancedMicrophoneAudioEngine {
                 echoCancellationEnabled: configuration.echoCancellationEnabled
             )
             currentConfiguration = stored
+            encoderOutputFormat = encoderFormat
+            consecutiveAECDropCount = 0
             standaloneAUHAL = au
             auhalChannelCount = channelCount
             auhalSampleRate = sampleRate
@@ -501,6 +510,7 @@ final class AdvancedMicrophoneAudioEngine {
             withStateLock {
                 standaloneAUHAL = nil
                 currentConfiguration = nil
+                encoderOutputFormat = nil
                 activeStreamID = 0
             }
             throw AdvancedMicrophoneAudioEngineError.deviceUnavailable
@@ -514,6 +524,7 @@ final class AdvancedMicrophoneAudioEngine {
             withStateLock {
                 standaloneAUHAL = nil
                 currentConfiguration = nil
+                encoderOutputFormat = nil
                 activeStreamID = 0
             }
             throw AdvancedMicrophoneAudioEngineError.engineStartFailed
@@ -527,6 +538,7 @@ final class AdvancedMicrophoneAudioEngine {
             withStateLock {
                 standaloneAUHAL = nil
                 currentConfiguration = nil
+                encoderOutputFormat = nil
                 activeStreamID = 0
             }
             throw AdvancedMicrophoneAudioEngineError.engineStartFailed
@@ -537,6 +549,8 @@ final class AdvancedMicrophoneAudioEngine {
 
     private func stopLocked() {
         echoCanceller = nil
+        encoderOutputFormat = nil
+        consecutiveAECDropCount = 0
 
         // Stop AVAudioEngine path.
         // Capture mixerNode before clearState (which sets it to nil).
@@ -567,6 +581,7 @@ final class AdvancedMicrophoneAudioEngine {
             freeAUHALRenderBuffers()
             withStateLock {
                 currentConfiguration = nil
+                encoderOutputFormat = nil
                 activeStreamID = 0
             }
         }
@@ -688,15 +703,17 @@ final class AdvancedMicrophoneAudioEngine {
         guard let snapshot: StateSnapshot = withStateLock({
             guard engine != nil || standaloneAUHAL != nil,
                   let configuration = currentConfiguration,
+                  let encoderFormat = encoderOutputFormat,
                   activeStreamID > 0 else {
                 return nil
             }
-            return StateSnapshot(configuration: configuration, streamID: activeStreamID)
+            return StateSnapshot(configuration: configuration, streamID: activeStreamID, encoderFormat: encoderFormat)
         }) else {
             return
         }
 
         let configuration = snapshot.configuration
+        let encoderFormat = snapshot.encoderFormat
 
         let selection = resolvedSelection(for: configuration.preset, availableChannels: availableChannels, physicalChannels: configuration.device.inputChannels)
 
@@ -748,27 +765,93 @@ final class AdvancedMicrophoneAudioEngine {
         }
 
         // Apply WebRTC AEC3 on Int16 PCM data.
-        let samples: [Int16]
+        var samples: [Int16]
         if let aec = echoCanceller {
             let processed = int16Buffer.withUnsafeBufferPointer { buf in
                 guard let baseAddress = buf.baseAddress else { return [Int16]() }
                 return aec.processCapture(baseAddress, count: adaptedCount)
             }
             if processed.isEmpty {
-                // AEC hasn't accumulated a full 10ms frame yet; skip this chunk.
-                return
+                consecutiveAECDropCount += 1
+                if consecutiveAECDropCount < maxConsecutiveAECDrops {
+                    return
+                }
+                AudioCaptureDiagnostics.shared.recordAECPassthrough()
+                AudioLogger.log("AEC: passthrough after %d empty outputs", consecutiveAECDropCount)
+                samples = Array(int16Buffer.prefix(adaptedCount))
+            } else {
+                consecutiveAECDropCount = 0
+                samples = processed
             }
-            samples = processed
         } else {
+            consecutiveAECDropCount = 0
             samples = Array(int16Buffer.prefix(adaptedCount))
         }
 
+        var workingSamples = samples
+        var workingFrameCount = workingSamples.count / targetChannels
+        guard workingFrameCount > 0 else { return }
+
+        let captureRate = configuration.targetFormat.sampleRate
+        let outputRate = encoderFormat.sampleRate
+        let outputChannels = max(encoderFormat.channels, 1)
+
+        if targetChannels != outputChannels {
+            let channelAdaptedCount = workingFrameCount * outputChannels
+            if adaptedBuffer.count < workingSamples.count {
+                adaptedBuffer = [Float](repeating: 0, count: workingSamples.count)
+            }
+            for index in 0..<workingSamples.count {
+                adaptedBuffer[index] = Float(workingSamples[index]) / 32_767.0
+            }
+            if selectedBuffer.count < channelAdaptedCount {
+                selectedBuffer = [Float](repeating: 0, count: channelAdaptedCount)
+            }
+            adaptChannelCountInPlace(
+                from: &adaptedBuffer,
+                to: &selectedBuffer,
+                frameCount: workingFrameCount,
+                sourceChannels: targetChannels,
+                targetChannels: outputChannels
+            )
+            if int16Buffer.count < channelAdaptedCount {
+                int16Buffer = [Int16](repeating: 0, count: channelAdaptedCount)
+            }
+            for index in 0..<channelAdaptedCount {
+                int16Buffer[index] = floatToPCM16(selectedBuffer[index])
+            }
+            workingSamples = Array(int16Buffer.prefix(channelAdaptedCount))
+            workingFrameCount = workingSamples.count / outputChannels
+        }
+
+        let resampled: AudioPCMResampler.Result
+        if abs(captureRate - outputRate) >= 0.5 {
+            resampled = AudioPCMResampler.resampleInterleaved(
+                workingSamples,
+                frameCount: workingFrameCount,
+                channels: outputChannels,
+                inputRate: captureRate,
+                outputRate: outputRate
+            )
+        } else {
+            resampled = AudioPCMResampler.Result(samples: workingSamples, frameCount: workingFrameCount)
+        }
+
+        let peak = resampled.samples.reduce(Int32(0)) { partial, sample in
+            max(partial, abs(Int32(sample)))
+        }
+        AudioCaptureDiagnostics.shared.recordChunk(
+            sampleRate: Int32(outputRate.rounded()),
+            peak: peak,
+            nonZero: peak > 32
+        )
+
         let chunk = AdvancedMicrophoneAudioChunk(
             streamID: snapshot.streamID,
-            sampleRate: Int32(configuration.targetFormat.sampleRate.rounded()),
-            channels: Int32(targetChannels),
-            sampleCount: Int32(samples.count / targetChannels),
-            samples: samples
+            sampleRate: Int32(outputRate.rounded()),
+            channels: Int32(outputChannels),
+            sampleCount: Int32(resampled.frameCount),
+            samples: resampled.samples
         )
 
         onAudioChunk(chunk)
@@ -786,6 +869,7 @@ final class AdvancedMicrophoneAudioEngine {
             engine = nil
             if standaloneAUHAL == nil {
                 currentConfiguration = nil
+                encoderOutputFormat = nil
                 activeStreamID = 0
             }
             mixerNode = nil

--- a/App/ttaccessible/Services/AdvancedMicrophoneSettingsStore.swift
+++ b/App/ttaccessible/Services/AdvancedMicrophoneSettingsStore.swift
@@ -35,7 +35,23 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
             }
             .store(in: &cancellables)
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleStopPreviewNotification),
+            name: .stopAdvancedMicrophonePreview,
+            object: nil
+        )
+
         refreshState(normalizeIfNeeded: true)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func handleStopPreviewNotification() {
+        stopPreview()
     }
 
     var advancedPreferences: AdvancedInputAudioPreferences {

--- a/App/ttaccessible/Services/AudioCaptureDiagnostics.swift
+++ b/App/ttaccessible/Services/AudioCaptureDiagnostics.swift
@@ -1,0 +1,125 @@
+//
+//  AudioCaptureDiagnostics.swift
+//  ttaccessible
+//
+
+import Foundation
+
+/// Throttled counters for microphone capture and TeamTalk injection diagnostics.
+final class AudioCaptureDiagnostics {
+    static let shared = AudioCaptureDiagnostics()
+
+    private let lock = NSLock()
+    private var lastLogTime: CFAbsoluteTime = 0
+    private let logInterval: CFAbsoluteTime = 1.0
+
+    private(set) var capturePath = "none"
+    private(set) var captureSampleRate: Int = 0
+    private(set) var outputSampleRate: Int = 0
+
+    private var chunkCount: UInt64 = 0
+    private var insertAttemptCount: UInt64 = 0
+    private var insertSuccessCount: UInt64 = 0
+    private var insertDropCount: UInt64 = 0
+    private var gatedDropCount: UInt64 = 0
+    private var peakSample: Int32 = 0
+    private var nonZeroChunkCount: UInt64 = 0
+    private var aecPassthroughCount: UInt64 = 0
+
+    private init() {}
+
+    func resetForNewCapture(path: String, captureRate: Int, outputRate: Int) {
+        lock.lock()
+        capturePath = path
+        captureSampleRate = captureRate
+        outputSampleRate = outputRate
+        chunkCount = 0
+        insertAttemptCount = 0
+        insertSuccessCount = 0
+        insertDropCount = 0
+        gatedDropCount = 0
+        peakSample = 0
+        nonZeroChunkCount = 0
+        aecPassthroughCount = 0
+        lastLogTime = 0
+        lock.unlock()
+        AudioLogger.log(
+            "capture start: path=%@ captureRate=%d outputRate=%d",
+            path,
+            captureRate,
+            outputRate
+        )
+    }
+
+    func recordChunk(sampleRate: Int32, peak: Int32, nonZero: Bool) {
+        lock.lock()
+        chunkCount += 1
+        if peak > peakSample {
+            peakSample = peak
+        }
+        if nonZero {
+            nonZeroChunkCount += 1
+        }
+        let shouldLog = shouldEmitLogLocked()
+        let snapshot = shouldLog ? snapshotLocked(chunkRate: Int(sampleRate)) : nil
+        lock.unlock()
+
+        if let snapshot {
+            AudioLogger.log(snapshot)
+        }
+    }
+
+    func recordAECPassthrough() {
+        lock.lock()
+        aecPassthroughCount += 1
+        lock.unlock()
+    }
+
+    func recordInsertAttempt(sampleRate: Int32, accepted: Bool, gated: Bool) {
+        lock.lock()
+        if gated {
+            gatedDropCount += 1
+        } else {
+            insertAttemptCount += 1
+            if accepted {
+                insertSuccessCount += 1
+            } else {
+                insertDropCount += 1
+            }
+        }
+        let shouldLog = shouldEmitLogLocked()
+        let snapshot = shouldLog ? snapshotLocked(chunkRate: Int(sampleRate)) : nil
+        lock.unlock()
+
+        if let snapshot {
+            AudioLogger.log(snapshot)
+        }
+    }
+
+    private func shouldEmitLogLocked() -> Bool {
+        let now = CFAbsoluteTimeGetCurrent()
+        guard now - lastLogTime >= logInterval else {
+            return false
+        }
+        lastLogTime = now
+        return true
+    }
+
+    private func snapshotLocked(chunkRate: Int) -> String {
+        String(
+            format: "audio diag: path=%@ captureRate=%d outputRate=%d chunkRate=%d chunks=%llu nonzero=%llu peak=%d inserts=%llu ok=%llu queueFull=%llu gated=%llu aecPass=%llu",
+            capturePath,
+            captureSampleRate,
+            outputSampleRate,
+            chunkRate,
+            chunkCount,
+            nonZeroChunkCount,
+            peakSample,
+            insertAttemptCount,
+            insertSuccessCount,
+            insertDropCount,
+            gatedDropCount,
+            aecPassthroughCount
+        )
+    }
+}

--- a/App/ttaccessible/Services/AudioPCMResampler.swift
+++ b/App/ttaccessible/Services/AudioPCMResampler.swift
@@ -1,0 +1,92 @@
+//
+//  AudioPCMResampler.swift
+//  ttaccessible
+//
+
+import Foundation
+
+/// Linear-interpolation resampler for interleaved Int16 PCM.
+enum AudioPCMResampler {
+    struct Result {
+        let samples: [Int16]
+        let frameCount: Int
+    }
+
+    static func resampleInterleaved(
+        _ samples: [Int16],
+        frameCount: Int,
+        channels: Int,
+        inputRate: Double,
+        outputRate: Double
+    ) -> Result {
+        guard frameCount > 0, channels > 0, inputRate > 0, outputRate > 0 else {
+            return Result(samples: samples, frameCount: frameCount)
+        }
+
+        if abs(inputRate - outputRate) < 0.5 {
+            return Result(samples: samples, frameCount: frameCount)
+        }
+
+        let ratio = outputRate / inputRate
+        let outputFrames = max(1, Int((Double(frameCount) * ratio).rounded()))
+        let outputSampleCount = outputFrames * channels
+        var output = [Int16](repeating: 0, count: outputSampleCount)
+
+        for outFrame in 0..<outputFrames {
+            let srcPosition = Double(outFrame) / ratio
+            let srcIndex = Int(srcPosition)
+            let fraction = srcPosition - Double(srcIndex)
+            let nextIndex = min(srcIndex + 1, frameCount - 1)
+
+            for channel in 0..<channels {
+                let idx0 = srcIndex * channels + channel
+                let idx1 = nextIndex * channels + channel
+                let sample0 = Double(samples[idx0])
+                let sample1 = Double(samples[idx1])
+                let value = sample0 + fraction * (sample1 - sample0)
+                output[outFrame * channels + channel] = Int16(clamping: Int(value.rounded()))
+            }
+        }
+
+        return Result(samples: output, frameCount: outputFrames)
+    }
+}
+
+#if DEBUG
+enum AudioPCMResamplerSelfTest {
+    @discardableResult
+    static func runAll() -> Bool {
+        let inputFrames = 441
+        let channels = 1
+        var input = [Int16](repeating: 0, count: inputFrames * channels)
+        for frame in 0..<inputFrames {
+            let t = Double(frame) / 44_100.0
+            input[frame] = Int16((sin(2 * .pi * 440 * t) * 16_000).rounded())
+        }
+
+        let result = AudioPCMResampler.resampleInterleaved(
+            input,
+            frameCount: inputFrames,
+            channels: channels,
+            inputRate: 44_100,
+            outputRate: 48_000
+        )
+
+        let expectedFrames = max(1, Int((Double(inputFrames) * (48_000.0 / 44_100.0)).rounded()))
+        guard result.frameCount == expectedFrames,
+              result.samples.count == expectedFrames * channels else {
+            AudioLogger.log("AudioPCMResamplerSelfTest: frame count mismatch got=%d expected=%d", result.frameCount, expectedFrames)
+            return false
+        }
+
+        let peak = result.samples.map { abs(Int32($0)) }.max() ?? 0
+        guard peak > 1_000 else {
+            AudioLogger.log("AudioPCMResamplerSelfTest: resampled signal too quiet peak=%d", peak)
+            return false
+        }
+
+        AudioLogger.log("AudioPCMResamplerSelfTest: passed frames=%d peak=%d", result.frameCount, peak)
+        return true
+    }
+}
+#endif

--- a/App/ttaccessible/Services/EchoCanceller.swift
+++ b/App/ttaccessible/Services/EchoCanceller.swift
@@ -45,6 +45,7 @@ final class EchoCanceller {
     private var referenceFramesFed: Int = 0
     private var captureFramesProcessed: Int = 0
     private var lastDiagnosticTime: CFAbsoluteTime = 0
+    private var didLogChannelMismatch = false
 
     init?(configuration: Configuration) {
         self.config = configuration
@@ -71,8 +72,10 @@ final class EchoCanceller {
     func feedReference(_ samples: UnsafePointer<Int16>, count: Int, channels: Int, sampleRate: Int = 0) {
         let frameSamples = config.frameSamplesPerChannel * config.channels
 
-        // If channel count matches, use directly; otherwise skip (rare mismatch case).
-        guard channels == config.channels else { return }
+        guard channels == config.channels else {
+            logChannelMismatchOnce(feedChannels: channels)
+            return
+        }
 
         let effectiveRate = sampleRate > 0 ? sampleRate : config.sampleRate
 
@@ -120,6 +123,16 @@ final class EchoCanceller {
         }
 
         logDiagnosticsIfNeeded(refRate: effectiveRate, refChannels: channels)
+    }
+
+    private func logChannelMismatchOnce(feedChannels: Int) {
+        guard didLogChannelMismatch == false else { return }
+        didLogChannelMismatch = true
+        AudioLogger.log(
+            "AEC: reference channel mismatch feed=%d config=%d — reference ignored",
+            feedChannels,
+            config.channels
+        )
     }
 
     private func logDiagnosticsIfNeeded(refRate: Int, refChannels: Int) {

--- a/App/ttaccessible/Services/Notification+Audio.swift
+++ b/App/ttaccessible/Services/Notification+Audio.swift
@@ -1,0 +1,11 @@
+//
+//  Notification+Audio.swift
+//  ttaccessible
+//
+
+import Foundation
+
+extension Notification.Name {
+    /// Posted before starting transmit capture so Preferences preview releases the mic.
+    static let stopAdvancedMicrophonePreview = Notification.Name("com.ttaccessible.stopAdvancedMicrophonePreview")
+}

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -118,10 +118,13 @@ extension TeamTalkConnectionController {
                 } catch {
                     AudioLogger.log("restartSoundSystem: mic restart failed — %@", error.localizedDescription)
                     self.voiceTransmissionEnabled = false
+                    self.inputAudioReady = false
+                    self.advancedMicrophoneTargetFormat = nil
                     SoundPlayer.shared.play(.voxMeDisable)
                     if let connectedRecord = self.connectedRecord {
                         self.publishSessionLocked(instance: instance, record: connectedRecord)
                     }
+                    self.lastAudioWarningMessage = L10n.text("connectedServer.audio.error.microphoneRestartFailed")
                 }
             }
 
@@ -287,6 +290,10 @@ extension TeamTalkConnectionController {
             return
         }
 
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .stopAdvancedMicrophonePreview, object: nil)
+        }
+
         guard let deviceInfo = InputAudioDeviceResolver.resolveCurrentInputDevice(for: preferencesStore.preferences.preferredInputDevice) else {
             throw TeamTalkConnectionError.internalError(L10n.text("preferences.audio.advanced.error.deviceUnavailable"))
         }
@@ -312,6 +319,7 @@ extension TeamTalkConnectionController {
             _ = try advancedMicrophoneEngine.start(configuration: configuration)
             advancedMicrophoneTargetFormat = targetFormat
             inputAudioReady = true
+            lastAudioWarningMessage = nil
 
             // Monitor sample rate changes on the active input device.
             let activeDeviceUID = deviceInfo.uid
@@ -392,6 +400,9 @@ extension TeamTalkConnectionController {
         }
         if recordingMuxedActive || recordingSeparateActive {
             status += " — " + L10n.text("connectedServer.audio.status.recording")
+        }
+        if let lastAudioWarningMessage {
+            status += " — " + lastAudioWarningMessage
         }
         return status
     }
@@ -533,9 +544,21 @@ extension TeamTalkConnectionController {
     }
 
     func insertAdvancedMicrophoneAudioChunkLocked(_ chunk: AdvancedMicrophoneAudioChunk) {
-        guard voiceTransmissionEnabled,
-              let instance,
-              TT_GetMyChannelID(instance) > 0 else {
+        guard let instance else {
+            AudioCaptureDiagnostics.shared.recordInsertAttempt(
+                sampleRate: chunk.sampleRate,
+                accepted: false,
+                gated: true
+            )
+            return
+        }
+        let inChannel = TT_GetMyChannelID(instance) > 0
+        guard voiceTransmissionEnabled, inChannel else {
+            AudioCaptureDiagnostics.shared.recordInsertAttempt(
+                sampleRate: chunk.sampleRate,
+                accepted: false,
+                gated: true
+            )
             return
         }
 
@@ -548,7 +571,13 @@ extension TeamTalkConnectionController {
             audioBlock.lpRawAudio = UnsafeMutableRawPointer(mutating: baseAddress)
             audioBlock.nSamples = chunk.sampleCount
             audioBlock.uSampleIndex = 0
-            if TT_InsertAudioBlock(instance, &audioBlock) == 0 {
+            let accepted = TT_InsertAudioBlock(instance, &audioBlock) != 0
+            AudioCaptureDiagnostics.shared.recordInsertAttempt(
+                sampleRate: chunk.sampleRate,
+                accepted: accepted,
+                gated: false
+            )
+            if accepted == false {
                 AudioLogger.log("TT_InsertAudioBlock: queue full, audio block dropped")
             }
         }

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Connection.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Connection.swift
@@ -704,7 +704,12 @@ extension TeamTalkConnectionController {
                                 if let connectedRecord {
                                     publishSessionLocked(instance: instance, record: connectedRecord)
                                 }
-                            } catch {}
+                            } catch {
+                                AudioLogger.log(
+                                    "auto-restore mic on join failed: %@",
+                                    error.localizedDescription
+                                )
+                            }
                         }
                         let joinedUsername = ttString(from: message.user.szUsername)
                         if let storedVolume = userVolumeStore.volume(forUsername: joinedUsername) {
@@ -952,7 +957,12 @@ extension TeamTalkConnectionController {
                                     try ensureAdvancedMicrophoneInputReadyLocked(instance: instance)
                                     voiceTransmissionEnabled = true
                                     SoundPlayer.shared.play(.voxMeEnable)
-                                } catch {}
+                                } catch {
+                                    AudioLogger.log(
+                                        "auto-restore mic on channel join failed: %@",
+                                        error.localizedDescription
+                                    )
+                                }
                             }
                             if recordingMuxedActive {
                                 restartMuxedRecordingForChannelChange()

--- a/App/ttaccessible/Services/TeamTalkConnectionController.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController.swift
@@ -104,6 +104,7 @@ final class TeamTalkConnectionController {
     var outputAudioReady = false
     var inputAudioReady = false
     var voiceTransmissionEnabled = false
+    var lastAudioWarningMessage: String?
     var masterMuted = false
     var hearMyselfEnabled = false
     var recordingMuxedActive = false

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -136,6 +136,7 @@
 "connectedServer.audio.error.inputStartFailed" = "Unable to initialize audio input.";
 "connectedServer.audio.error.notInChannel" = "You must join a channel before enabling the microphone.";
 "connectedServer.audio.error.microphonePermissionDenied" = "Microphone access was denied by macOS.";
+"connectedServer.audio.error.microphoneRestartFailed" = "Microphone stopped after an audio device change. Turn it on again.";
 "connectedServer.chat.sent" = "Message sent.";
 "connectedServer.chat.sender.unknown" = "User %@";
 "chat.sender.you" = "You";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -136,6 +136,7 @@
 "connectedServer.audio.error.inputStartFailed" = "Impossible d'initialiser l'entrée audio.";
 "connectedServer.audio.error.notInChannel" = "Vous devez rejoindre un canal avant d'activer le micro.";
 "connectedServer.audio.error.microphonePermissionDenied" = "L'accès au micro a été refusé par macOS.";
+"connectedServer.audio.error.microphoneRestartFailed" = "Le micro s'est arrêté après un changement de périphérique audio. Réactivez-le.";
 "connectedServer.chat.sent" = "Message envoyé.";
 "connectedServer.chat.sender.unknown" = "Utilisateur %@";
 "chat.sender.you" = "Vous";

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you already use TeamTalk on your Mac, you can import your saved servers:
 
 ## Architecture
 
-Native **macOS AppKit app** with SwiftUI preference panes. The audio pipeline uses a custom dual-path capture engine — AVAudioEngine for the system default input device, standalone AUHAL AudioUnit for non-default devices — bypassing the TeamTalk SDK's built-in audio capture (which causes crackling on macOS). Audio is injected into the SDK via `TT_InsertAudioBlock` through a virtual sound device.
+Native **macOS AppKit app** with SwiftUI preference panes. The audio pipeline uses a custom AUHAL capture engine (explicit CoreAudio device binding for every input, including system default) bypassing the TeamTalk SDK's built-in audio capture (which causes crackling on macOS). Captured PCM is resampled to the channel codec rate before injection via `TT_InsertAudioBlock` through a virtual sound device.
 
 Echo cancellation uses WebRTC AEC3 (from `webrtc-audio-processing` v2.0, WebRTC M131) with the actual speaker output captured via Core Audio taps as the reference signal — not just the decoded TeamTalk audio. This allows cancellation of VoiceOver, system sounds, and all other audio.
 


### PR DESCRIPTION
  System default used AVAudioEngine while named devices used AUHAL with
  explicit Core Audio device binding, which broke channel transmit when
  TeamTalk also held output and the virtual input device.
  - Capture all inputs via AUHAL with an explicit device ID
  - Resample PCM to the channel codec rate before TT_InsertAudioBlock
  - Stop Preferences preview before starting transmit capture
  - Add throttled capture/inject diagnostics and mic-restart status text
  - Log AEC reference channel mismatches; passthrough after repeated AEC drops