### PR TITLE
Improve nickname UX: derive from computer name, apply live on change

### DIFF
--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -104,7 +104,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         userDriverDelegate: nil
     )
     private var updaterAutoCheckCancellable: AnyCancellable?
-
+    private var nicknameCancellable: AnyCancellable?
     private var pushToTalkModeCancellable: AnyCancellable?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -140,6 +140,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         handleLaunchTTFilesIfNeeded()
         processPendingTTFileURLsIfPossible()
         syncSparkleAutoCheckPreference()
+        syncNicknamePreference()
         scheduleLaunchUpdateCheck()
         configurePushToTalkObservers()
     }
@@ -181,6 +182,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func playPushToTalkBeep() {
         guard preferencesStore.preferences.pushToTalkBeepEnabled else { return }
         SoundPlayer.shared.play(.hotkey)
+    }
+
+    private func syncNicknamePreference() {
+        nicknameCancellable = preferencesStore.$preferences
+            .map(\.defaultNickname)
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] nickname in
+                guard let self else { return }
+                connectionController.changeNickname(to: nickname) { _ in }
+            }
     }
 
     private func syncSparkleAutoCheckPreference() {

--- a/App/ttaccessible/AppKit/SavedServersViewController.swift
+++ b/App/ttaccessible/AppKit/SavedServersViewController.swift
@@ -348,7 +348,7 @@ final class SavedServersViewController: NSViewController {
             password = try passwordStore.password(for: record.id) ?? ""
             channelPassword = try passwordStore.channelPassword(for: record.id) ?? record.initialChannelPassword
         } catch {
-            presentErrorAlert(message: error.localizedDescription)
+            openCredentialEditor(for: record, errorMessage: error.localizedDescription)
             return
         }
 
@@ -379,10 +379,14 @@ final class SavedServersViewController: NSViewController {
     }
 
     private func handleLoginFailure(for record: SavedServerRecord, error: TeamTalkConnectionError) {
+        openCredentialEditor(for: record, errorMessage: L10n.format("savedServers.alert.loginFailed.message", error.localizedDescription))
+    }
+
+    private func openCredentialEditor(for record: SavedServerRecord, errorMessage: String) {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = L10n.text("savedServers.alert.loginFailed.title")
-        alert.informativeText = L10n.format("savedServers.alert.loginFailed.message", error.localizedDescription)
+        alert.informativeText = errorMessage
         alert.addButton(withTitle: L10n.text("savedServers.alert.loginFailed.editCredentials"))
         alert.addButton(withTitle: L10n.text("savedServers.alert.loginFailed.cancel"))
 

--- a/App/ttaccessible/Models/AppPreferences.swift
+++ b/App/ttaccessible/Models/AppPreferences.swift
@@ -8,6 +8,17 @@
 import Foundation
 
 struct AppPreferences: Codable, Equatable {
+    static func nicknameFromComputerName() -> String {
+        let name = Host.current().localizedName ?? ""
+        if let idx = name.firstIndex(of: "'") {
+            let firstName = String(name[name.startIndex..<idx])
+            if !firstName.isEmpty { return firstName }
+        }
+        let firstWord = name.components(separatedBy: .whitespaces).first ?? ""
+        return firstWord.isEmpty ? "TTAccessible" : firstWord
+    }
+
+
     enum ChannelSortMode: String, Codable, CaseIterable {
         case name
         case userCount
@@ -156,7 +167,7 @@ struct AppPreferences: Codable, Equatable {
     var microphoneMode: MicrophoneMode
     var pushToTalkBeepEnabled: Bool
     init(
-        defaultNickname: String = "TTAccessible",
+        defaultNickname: String = AppPreferences.nicknameFromComputerName(),
         defaultStatusMessage: String = "",
         defaultGender: TeamTalkGender = .neutral,
         autoAwayTimeoutMinutes: Int = 3,
@@ -289,7 +300,7 @@ struct AppPreferences: Codable, Equatable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        defaultNickname = try container.decodeIfPresent(String.self, forKey: .defaultNickname) ?? "TTAccessible"
+        defaultNickname = try container.decodeIfPresent(String.self, forKey: .defaultNickname) ?? AppPreferences.nicknameFromComputerName()
         defaultStatusMessage = try container.decodeIfPresent(String.self, forKey: .defaultStatusMessage) ?? ""
         defaultGender = try container.decodeIfPresent(TeamTalkGender.self, forKey: .defaultGender) ?? .neutral
         autoAwayTimeoutMinutes = Self.clampAutoAwayTimeoutMinutes(try container.decodeIfPresent(Int.self, forKey: .autoAwayTimeoutMinutes) ?? 3)

--- a/App/ttaccessible/Models/SavedServerDraft.swift
+++ b/App/ttaccessible/Models/SavedServerDraft.swift
@@ -25,7 +25,7 @@ struct SavedServerDraft: Equatable {
         tcpPort: String = "10333",
         udpPort: String = "10333",
         encrypted: Bool = false,
-        nickname: String = "TTAccessible",
+        nickname: String = AppPreferences.nicknameFromComputerName(),
         username: String = "",
         password: String = "",
         initialChannelPath: String = "",


### PR DESCRIPTION
## Summary

- **Smart default nickname**: parsed from the Mac's computer name — e.g. \"Quinton's MacBook Air\" → \"Quinton\" — so most users connect with a sensible name without any setup
- **Live nickname updates**: changing the nickname in Preferences now takes effect immediately on any connected server, no restart required
- **Keychain error recovery**: when a saved password can't be read from the keychain (e.g. after re-signing), the app now opens the credential editor instead of a dead-end error alert

## Test plan

- [ ] Fresh install (no saved preferences): verify nickname defaults to first name from computer name
- [ ] Change nickname in Preferences while connected: verify it updates on the server immediately
- [ ] Simulate keychain failure: verify \"Edit Credentials\" dialog appears instead of a dead-end error

🤖 Generated with [Claude Code](https://claude.com/claude-code)