### PR TITLE
Polish post-merge media streaming follow-ups

### DIFF
--- a/App/ttaccessible/Services/TeamTalkConnectionController+MediaStreaming.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+MediaStreaming.swift
@@ -398,8 +398,7 @@ extension TeamTalkConnectionController {
             publishMediaStreamingProgressLocked()
             return
         }
-        if mediaStreamingResumeAnchorMSec != nil,
-           let anchorMSec = mediaStreamingResumeAnchorMSec,
+        if let anchorMSec = mediaStreamingResumeAnchorMSec,
            elapsedMSec + 500 >= anchorMSec {
             mediaStreamingResumeAnchorMSec = nil
             mediaStreamingResumeAnchorUntil = nil

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -554,9 +554,6 @@
 "mediaStream.error.unsupportedFormat" = "This media format is not supported for streaming.";
 "mediaStream.error.unsupportedFormat.detail" = "This file cannot be streamed in TeamTalk. %@";
 "mediaStream.error.reason.sdkUnsupported" = "TeamTalk cannot open this file format.";
-"mediaStream.error.reason.videoCodec" = "Video codec is %@ (supported: H.264, MJPEG, MPEG-1, MPEG-4).";
-"mediaStream.error.reason.videoCodecBlocked" = "Video codec is %@ (HEVC, VP9, and AV1 are not supported).";
-"mediaStream.error.reason.videoResolution" = "Video resolution is %1$@×%2$@ (maximum 1280 pixels on the longest side).";
 "mediaStream.error.reason.tenBitVideo" = "10-bit video is not supported.";
 "history.mediaStreamingStarted" = "Streaming media: %@";
 "history.mediaStreamingFinished" = "Streaming finished";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -537,7 +537,7 @@
 "shortcuts.mediaStream.startURL" = "Diffuser une URL…";
 "shortcuts.mediaStream.stop" = "Arrêter la diffusion";
 "mediaStream.panel.title" = "Diffuser un fichier média";
-"mediaStream.panel.message" = "Choisissez un fichier audio ou vidéo à diffuser dans le canal. La prise en charge vidéo dépend de ce que TeamTalk peut ouvrir sur votre Mac. La vidéo 10 bits n'est pas prise en charge.";
+"mediaStream.panel.message" = "Choisissez un fichier audio ou vidéo à diffuser dans le canal. La prise en charge vidéo dépend des formats que TeamTalk peut décoder sur votre Mac. La vidéo 10 bits n'est pas prise en charge.";
 "mediaStream.panel.choose" = "Diffuser";
 "mediaStream.url.prompt.title" = "Diffuser une URL";
 "mediaStream.url.prompt.message" = "Saisissez l'URL d'un flux audio (radio internet, http, rtmp, rtsp).";
@@ -554,9 +554,6 @@
 "mediaStream.error.unsupportedFormat" = "Ce format média n'est pas pris en charge pour la diffusion.";
 "mediaStream.error.unsupportedFormat.detail" = "Ce fichier ne peut pas être diffusé dans TeamTalk. %@";
 "mediaStream.error.reason.sdkUnsupported" = "TeamTalk ne peut pas ouvrir ce format de fichier.";
-"mediaStream.error.reason.videoCodec" = "Le codec vidéo est %@ (pris en charge : H.264, MJPEG, MPEG-1, MPEG-4).";
-"mediaStream.error.reason.videoCodecBlocked" = "Le codec vidéo est %@ (HEVC, VP9 et AV1 ne sont pas pris en charge).";
-"mediaStream.error.reason.videoResolution" = "La résolution vidéo est %1$@×%2$@ (1280 pixels maximum sur le côté le plus long).";
 "mediaStream.error.reason.tenBitVideo" = "La vidéo 10 bits n'est pas prise en charge.";
 "history.mediaStreamingStarted" = "Diffusion du média : %@";
 "history.mediaStreamingFinished" = "Diffusion du média terminée";


### PR DESCRIPTION
## Summary
- Improve French `mediaStream.panel.message` copy: "dépend des formats que TeamTalk peut décoder" instead of the calque "dépend de ce que TeamTalk peut ouvrir"
- Remove unused `mediaStream.error.reason.videoCodec`, `videoCodecBlocked`, and `videoResolution` strings (EN + FR) — no longer referenced after deferring codec/resolution checks to the SDK (d8e9ce2)
- Simplify `updateMediaStreamingProgressLocked`: drop redundant `!= nil` before `if let anchorMSec = mediaStreamingResumeAnchorMSec`

## Test plan
- [ ] Open "Stream Media File" panel and confirm FR message reads naturally
- [x] Confirm unsupported-format errors still show `sdkUnsupported` / `tenBitVideo` where applicable
- [x] Smoke-test pause → seek → resume on a media stream (resume anchor clearing unchanged in behavior)


Made with [Cursor](https://cursor.com)