### PR TITLE
fix(audio): restart only on meaningful route changes

### DIFF
--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -94,7 +94,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var pendingUnsavedServerConfiguration: PendingUnsavedServerConfiguration?
 
     private var deviceChangeObserver: Any?
-    private var globalDeviceChangeWorkItem: DispatchWorkItem?
 
     private lazy var updaterController: SPUStandardUpdaterController = SPUStandardUpdaterController(
         startingUpdater: true,
@@ -121,13 +120,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             forName: AudioDeviceChangeMonitor.audioDevicesDidChange,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
-            self?.globalDeviceChangeWorkItem?.cancel()
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.connectionController.restartSoundSystem { _ in }
-            }
-            self?.globalDeviceChangeWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500), execute: workItem)
+        ) { [weak self] notification in
+            let selector = notification.userInfo?[AudioDeviceChangeMonitor.selectorUserInfoKey] as? UInt32 ?? 0
+            self?.connectionController.handleDebouncedAudioHardwareChange(selector: selector)
         }
         requestNotificationPermission()
         showSavedServersWindow()

--- a/App/ttaccessible/Models/AudioRoutingSnapshot.swift
+++ b/App/ttaccessible/Models/AudioRoutingSnapshot.swift
@@ -1,0 +1,18 @@
+//
+//  AudioRoutingSnapshot.swift
+//  ttaccessible
+//
+
+import Foundation
+
+/// Captures the audio routing state that matters for live TeamTalk sessions.
+/// Used to ignore benign CoreAudio device-list churn (e.g. Continuity devices)
+/// while still reacting to real route changes (AirPods, unplugged hardware, defaults).
+struct AudioRoutingSnapshot: Equatable {
+    var resolvedInputUID: String?
+    var defaultInputUID: String?
+    var defaultOutputUID: String?
+    var preferredOutputPersistentID: String?
+    var outputPersistentIDInCatalog: Bool
+    var activeInputSampleRate: Double
+}

--- a/App/ttaccessible/Services/AppPreferencesStore.swift
+++ b/App/ttaccessible/Services/AppPreferencesStore.swift
@@ -575,16 +575,14 @@ final class AudioPreferencesStore: ObservableObject {
             catalogStale = true
             return
         }
-        // AppDelegate's debounced observer calls TT_RestartSoundSystem() at 500ms.
-        // We schedule our UI refresh at 1s to ensure the restart has completed
-        // and TT_GetSoundDevices() returns fresh data.
+        // Debounced hardware handler refreshes the TeamTalk device cache; match that timing.
         deviceChangeRefreshWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             self?.loadCatalogIfNeeded(forceRefresh: true)
             self?.advancedSettingsStore.refresh()
         }
         deviceChangeRefreshWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(1000), execute: workItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(600), execute: workItem)
     }
 
     func suspendWhenHidden() {

--- a/App/ttaccessible/Services/AudioDeviceChangeMonitor.swift
+++ b/App/ttaccessible/Services/AudioDeviceChangeMonitor.swift
@@ -12,6 +12,7 @@ import Foundation
 /// Posts `Notification.Name.audioDevicesDidChange` on the main thread when a change is detected.
 final class AudioDeviceChangeMonitor {
     static let audioDevicesDidChange = Notification.Name("TTAccessibleAudioDevicesDidChange")
+    static let selectorUserInfoKey = "TTAccessibleAudioChangeSelector"
 
     private var isListening = false
     private var monitoredInputDeviceID: AudioDeviceID = kAudioObjectUnknown
@@ -117,7 +118,11 @@ final class AudioDeviceChangeMonitor {
             updateSampleRateMonitoring()
         }
         DispatchQueue.main.async {
-            NotificationCenter.default.post(name: Self.audioDevicesDidChange, object: nil)
+            NotificationCenter.default.post(
+                name: Self.audioDevicesDidChange,
+                object: nil,
+                userInfo: [Self.selectorUserInfoKey: selector]
+            )
         }
     }
 

--- a/App/ttaccessible/Services/InputAudioDeviceResolver.swift
+++ b/App/ttaccessible/Services/InputAudioDeviceResolver.swift
@@ -166,24 +166,37 @@ enum InputAudioDeviceResolver {
         }
     }
 
-    private nonisolated static func defaultInputDevice(from devices: [InputAudioDeviceInfo]) -> InputAudioDeviceInfo? {
+    nonisolated static func defaultInputDeviceUID() -> String? {
+        coreAudioDefaultDeviceUID(selector: kAudioHardwarePropertyDefaultInputDevice)
+    }
+
+    nonisolated static func defaultOutputDeviceUID() -> String? {
+        coreAudioDefaultDeviceUID(selector: kAudioHardwarePropertyDefaultOutputDevice)
+    }
+
+    private nonisolated static func coreAudioDefaultDeviceUID(selector: AudioObjectPropertySelector) -> String? {
         let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mSelector: selector,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
         var deviceID = AudioObjectID()
         var dataSize = UInt32(MemoryLayout<AudioObjectID>.size)
-        guard AudioObjectGetPropertyData(systemObjectID, &address, 0, nil, &dataSize, &deviceID) == noErr,
-              let uid = stringProperty(
-                objectID: deviceID,
-                selector: kAudioDevicePropertyDeviceUID,
-                scope: kAudioObjectPropertyScopeGlobal
-              ) else {
+        guard AudioObjectGetPropertyData(systemObjectID, &address, 0, nil, &dataSize, &deviceID) == noErr else {
             return nil
         }
+        return stringProperty(
+            objectID: deviceID,
+            selector: kAudioDevicePropertyDeviceUID,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+    }
 
+    private nonisolated static func defaultInputDevice(from devices: [InputAudioDeviceInfo]) -> InputAudioDeviceInfo? {
+        guard let uid = defaultInputDeviceUID() else {
+            return nil
+        }
         return devices.first(where: { $0.uid == uid })
     }
 

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -87,11 +87,6 @@ extension TeamTalkConnectionController {
                 DispatchQueue.main.async { completion(.success(())) }
                 return
             }
-            if Date() < self.suppressDeviceChangeUntil {
-                AudioLogger.log("restartSoundSystem: skipped (device-change suppression active)")
-                DispatchQueue.main.async { completion(.success(())) }
-                return
-            }
             self.isRestartingSoundSystem = true
             defer { self.isRestartingSoundSystem = false }
 
@@ -183,7 +178,6 @@ extension TeamTalkConnectionController {
                 return
             }
 
-            self.extendDeviceChangeSuppressionLocked(duration: 5.0)
             let hadActiveAudio = self.outputAudioReady || self.inputAudioReady || self.isAnyMicrophoneEngineRunning
             if hadActiveAudio {
                 // User-changed routing needs a fresh TeamTalk device list, not just close/reopen.

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -59,7 +59,19 @@ extension TeamTalkConnectionController {
     func suppressNextDeviceChange(for duration: TimeInterval) {
         queue.async { [weak self] in
             guard let self else { return }
-            self.suppressDeviceChangeUntil = Date().addingTimeInterval(duration)
+            self.extendDeviceChangeSuppressionLocked(duration: duration)
+        }
+    }
+
+    func handleDebouncedAudioHardwareChange(selector: UInt32) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.audioHardwareChangeWorkItem?.cancel()
+            let workItem = DispatchWorkItem { [weak self] in
+                self?.processAudioHardwareChangeLocked(selector: selector)
+            }
+            self.audioHardwareChangeWorkItem = workItem
+            self.queue.asyncAfter(deadline: .now() + .milliseconds(500), execute: workItem)
         }
     }
 
@@ -76,13 +88,14 @@ extension TeamTalkConnectionController {
                 return
             }
             if Date() < self.suppressDeviceChangeUntil {
-                AudioLogger.log("restartSoundSystem: skipped (suppressed for speaker tap)")
+                AudioLogger.log("restartSoundSystem: skipped (device-change suppression active)")
                 DispatchQueue.main.async { completion(.success(())) }
                 return
             }
             self.isRestartingSoundSystem = true
             defer { self.isRestartingSoundSystem = false }
 
+            self.extendDeviceChangeSuppressionLocked(duration: 5.0)
             AudioLogger.log("restartSoundSystem: begin")
 
             let hadMic = self.isAnyMicrophoneEngineRunning || self.inputAudioReady
@@ -145,6 +158,7 @@ extension TeamTalkConnectionController {
                 }
             }
 
+            self.captureAudioRoutingSnapshotLocked()
             AudioLogger.log("restartSoundSystem: done")
             DispatchQueue.main.async { completion(.success(())) }
         }
@@ -169,8 +183,28 @@ extension TeamTalkConnectionController {
                 return
             }
 
+            self.extendDeviceChangeSuppressionLocked(duration: 5.0)
+            let hadActiveAudio = self.outputAudioReady || self.inputAudioReady || self.isAnyMicrophoneEngineRunning
+            if hadActiveAudio {
+                // User-changed routing needs a fresh TeamTalk device list, not just close/reopen.
+                self.restartSoundSystem { [weak self] result in
+                    guard let self else { return }
+                    switch result {
+                    case .success:
+                        if let instance = self.instance, let record = self.connectedRecord {
+                            self.publishSessionLocked(instance: instance, record: record)
+                        }
+                        DispatchQueue.main.async { completion(.success(())) }
+                    case .failure(let error):
+                        DispatchQueue.main.async { completion(.failure(error)) }
+                    }
+                }
+                return
+            }
+
             do {
                 try self.reinitializeAudioDevicesLocked(instance: instance, preferences: preferences)
+                self.captureAudioRoutingSnapshotLocked()
                 self.publishSessionLocked(instance: instance, record: record)
                 DispatchQueue.main.async {
                     completion(.success(()))
@@ -247,6 +281,7 @@ extension TeamTalkConnectionController {
                 return
             }
 
+            self.extendDeviceChangeSuppressionLocked(duration: 3.0)
             do {
                 try self.ensureAdvancedMicrophoneInputReadyLocked(instance: instance)
                 self.voiceTransmissionEnabled = true
@@ -256,6 +291,7 @@ extension TeamTalkConnectionController {
                 DispatchQueue.main.async {
                     preferencesStore.updateLastVoiceTransmissionEnabled(true)
                 }
+                self.captureAudioRoutingSnapshotLocked()
                 self.finishOnMain(.success(()), completion: completion)
             } catch {
                 self.finishOnMain(.failure(error), completion: completion)
@@ -397,6 +433,8 @@ extension TeamTalkConnectionController {
         if wasVoiceTransmissionEnabled {
             voiceTransmissionEnabled = true
         }
+
+        captureAudioRoutingSnapshotLocked()
     }
 
     func makeAudioStatusText() -> String {
@@ -513,7 +551,7 @@ extension TeamTalkConnectionController {
         }
         // Suppress device change notifications briefly — creating the aggregate device
         // triggers kAudioHardwarePropertyDevices which would restart the sound system.
-        suppressDeviceChangeUntil = Date().addingTimeInterval(2.0)
+        extendDeviceChangeSuppressionLocked(duration: 2.0)
         guard tap.start() else {
             AudioLogger.log("AEC: speaker tap failed to start")
             suppressDeviceChangeUntil = .distantPast
@@ -985,6 +1023,137 @@ extension TeamTalkConnectionController {
             return String(format: "+%.0f dB", rounded)
         }
         return String(format: "%.0f dB", rounded)
+    }
+
+    // MARK: - Hardware change handling
+
+    func extendDeviceChangeSuppressionLocked(duration: TimeInterval) {
+        suppressDeviceChangeUntil = max(suppressDeviceChangeUntil, Date().addingTimeInterval(duration))
+    }
+
+    func processAudioHardwareChangeLocked(selector: UInt32) {
+        if Date() < suppressDeviceChangeUntil {
+            AudioLogger.log("processAudioHardwareChange: suppressed")
+            return
+        }
+
+        let previous = lastAudioRoutingSnapshot
+        cachedSoundDevices = []
+        cachedAudioDeviceCatalog = nil
+        let current = makeAudioRoutingSnapshotLocked()
+
+        let needsReinit = needsAudioReinitializationLocked(
+            previous: previous,
+            current: current,
+            selector: selector
+        )
+
+        AudioLogger.log(
+            "processAudioHardwareChange: selector=0x%08X needsReinit=%d in=%@ out=%@",
+            selector,
+            needsReinit ? 1 : 0,
+            current.resolvedInputUID ?? "nil",
+            current.preferredOutputPersistentID ?? "default"
+        )
+
+        lastAudioRoutingSnapshot = current
+
+        guard needsReinit,
+              let instance,
+              connectedRecord != nil,
+              outputAudioReady || inputAudioReady || isAnyMicrophoneEngineRunning else {
+            AudioLogger.log("processAudioHardwareChange: catalog refresh only")
+            return
+        }
+
+        AudioLogger.log("processAudioHardwareChange: restarting sound system for route change")
+        restartSoundSystem { [weak self] result in
+            guard let self else { return }
+            if case .success = result,
+               let instance = self.instance,
+               let record = self.connectedRecord {
+                self.publishSessionLocked(instance: instance, record: record)
+            }
+        }
+    }
+
+    func captureAudioRoutingSnapshotLocked() {
+        lastAudioRoutingSnapshot = makeAudioRoutingSnapshotLocked()
+    }
+
+    func makeAudioRoutingSnapshotLocked() -> AudioRoutingSnapshot {
+        let preferences = preferencesStore.preferences
+        let resolvedInput = InputAudioDeviceResolver.resolveCurrentInputDevice(
+            for: preferences.preferredInputDevice
+        )
+        let outputPreference = preferences.preferredOutputDevice
+        let outputPersistentID = outputPreference.persistentID
+        let catalog = availableAudioDevicesLocked(forceRefresh: true)
+        let outputInCatalog: Bool
+        if let outputPersistentID, outputPersistentID.isEmpty == false {
+            outputInCatalog = catalog.outputDevices.contains { $0.persistentID == outputPersistentID }
+        } else {
+            outputInCatalog = catalog.outputDevices.isEmpty == false
+        }
+
+        return AudioRoutingSnapshot(
+            resolvedInputUID: resolvedInput?.uid,
+            defaultInputUID: InputAudioDeviceResolver.defaultInputDeviceUID(),
+            defaultOutputUID: InputAudioDeviceResolver.defaultOutputDeviceUID(),
+            preferredOutputPersistentID: outputPersistentID,
+            outputPersistentIDInCatalog: outputInCatalog,
+            activeInputSampleRate: resolvedInput?.nominalSampleRate ?? 0
+        )
+    }
+
+    func needsAudioReinitializationLocked(
+        previous: AudioRoutingSnapshot?,
+        current: AudioRoutingSnapshot,
+        selector: UInt32
+    ) -> Bool {
+        guard let previous else {
+            return false
+        }
+
+        let inputPreference = preferencesStore.preferences.preferredInputDevice
+        let outputPreference = preferencesStore.preferences.preferredOutputDevice
+
+        if inputPreference.usesSystemDefault,
+           previous.defaultInputUID != current.defaultInputUID {
+            return true
+        }
+
+        if outputPreference.usesSystemDefault,
+           previous.defaultOutputUID != current.defaultOutputUID {
+            return true
+        }
+
+        // Explicit input preference: only react when the chosen device disappears,
+        // not when unrelated devices (e.g. Continuity) are added to the global list.
+        if inputPreference.usesSystemDefault == false,
+           let persistentID = inputPreference.persistentID,
+           persistentID.isEmpty == false {
+            let stillAvailable = InputAudioDeviceResolver.availableInputDevices()
+                .contains { $0.uid == persistentID }
+            if previous.resolvedInputUID != nil, stillAvailable == false {
+                return true
+            }
+        }
+
+        if outputPreference.usesSystemDefault == false,
+           let persistentID = outputPreference.persistentID,
+           persistentID.isEmpty == false,
+           previous.outputPersistentIDInCatalog != current.outputPersistentIDInCatalog {
+            return true
+        }
+
+        if selector == kAudioDevicePropertyNominalSampleRate,
+           previous.resolvedInputUID == current.resolvedInputUID,
+           previous.activeInputSampleRate != current.activeInputSampleRate {
+            return true
+        }
+
+        return false
     }
 
 }

--- a/App/ttaccessible/Services/TeamTalkConnectionController.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController.swift
@@ -148,6 +148,8 @@ final class TeamTalkConnectionController {
     var lastChannelID: Int32 = 0
     var isRestartingSoundSystem = false
     var suppressDeviceChangeUntil = Date.distantPast
+    var audioHardwareChangeWorkItem: DispatchWorkItem?
+    var lastAudioRoutingSnapshot: AudioRoutingSnapshot?
     var lastAutoAwayCheckTime: CFAbsoluteTime = 0
     var isAutoAwayActive = false
     var autoAwayActivationTime: Date?


### PR DESCRIPTION
## Summary

Fixes unsolicited full audio restarts that caused ~1–2 second cutouts on both input and output, and could freeze the app when CoreAudio fired device-list notifications frequently.

**Problem:** On every `kAudioHardwarePropertyDevices` event (and related CoreAudio notifications), `AppDelegate` debounced a call to `TT_RestartSoundSystem()`. That tore down the mic, virtual input, output, and AEC speaker tap, then reopened everything—often ~2 seconds of dead air. Benign churn (Continuity “iPhone Microphone” appearing/disappearing, virtual cables, the app’s own AEC aggregate device on start/stop) triggered the same path as a real hardware change. A restart could also schedule another restart when the tap was destroyed, producing back-to-back outages.

**Fix:** Route hardware changes through a debounced handler that compares an `AudioRoutingSnapshot` (resolved input, system default in/out UIDs, preferred output still in catalog, active mic sample rate). Only restart when something that affects the live session actually changed:

- System default input or output changed (e.g. AirPods become default)
- Explicitly chosen input/output device unplugged or removed from the catalog
- Nominal sample rate changed on the active input device

Otherwise refresh the TeamTalk device cache only (`catalog refresh only` in logs)—no `TT_RestartSoundSystem`.

Additional behavior:

- **Preferences device changes** while audio is active still use a full `restartSoundSystem` so TeamTalk picks up the new routing reliably.
- **Suppression** during mic enable, manual restart, and speaker-tap lifecycle avoids restart cascades (including the first-time microphone permission dialog backlog).
- **Monitor** passes the CoreAudio property selector in the notification for sample-rate-specific handling.

## Evidence

Before: logs showed dozens of `restartSoundSystem: begin` per session, often in pairs within seconds, correlated with `kAudioHardwarePropertyDevices` and device count toggling 8↔9 (Continuity).

After: typical session shows `catalog refresh only` for irrelevant list changes, single `restarting sound system for route change` when system defaults change (e.g. AirPods connect/disconnect), aligned `inserts`/`chunks` on first mic enable, no restart storm on quit.

## Test plan

- [x] Connect to a server, enable mic (grant permission on first use)—no long delayed/echoed burst after allowing access
- [x] Use audio for several minutes with Continuity disabled—no random ~2 s cutouts; log should not spam `restartSoundSystem: begin`
- [ ] With a fixed (non-default) mic selected, plug/unplug unrelated devices—audio stays up; log shows `catalog refresh only`
- [x] Set input/output to System Default, connect/disconnect AirPods—one restart per real route change; audio follows defaults
- [ ] Change input/output in Preferences while connected—audio moves to selected devices
- [x] Manual “Refresh devices” in Preferences still performs a full restart


Made with [Cursor](https://cursor.com)