### PR TITLE
Add multi-profile support via a New Instance menu

### DIFF
--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -107,9 +107,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var pushToTalkModeCancellable: AnyCancellable?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        ProfileInstanceLock.acquire(for: ProfileContext.current)
         AudioLogger.clear()
         let sdkVersion = String(cString: TT_GetVersion())
-        AudioLogger.log("App launched — TeamTalk SDK %@", sdkVersion)
+        AudioLogger.log("App launched — TeamTalk SDK %@ — profile %@", sdkVersion, ProfileContext.current.slug)
         #if DEBUG
         _ = AudioPCMResamplerSelfTest.runAll()
         #endif
@@ -318,6 +319,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        ProfileInstanceLock.release(for: ProfileContext.current)
         connectionController.disconnectSynchronously()
         // The TeamTalk SDK's internal reactor thread sometimes outlives
         // TT_CloseTeamTalk and crashes when exit()'s static destructors race

--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -380,7 +380,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
            window.contentViewController is SavedServersViewController == false {
             let viewController = makeSavedServersViewController()
             window.contentViewController = viewController
-            window.title = L10n.text("savedServers.window.title")
+            window.title = ProfileContext.current.decorateWindowTitle(L10n.text("savedServers.window.title"))
         }
 
         menuState.setMode(.savedServers)
@@ -435,7 +435,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         savedServersWindowController?.window?.contentViewController = viewController
-        savedServersWindowController?.window?.title = L10n.format("connectedServer.window.title", session.displayName)
+        savedServersWindowController?.window?.title = ProfileContext.current.decorateWindowTitle(
+            L10n.format("connectedServer.window.title", session.displayName)
+        )
         menuState.setMode(.connectedServer)
         menuState.setHasSelection(false)
         if shouldActivateWindow {

--- a/App/ttaccessible/AppKit/AppDelegate+NewInstance.swift
+++ b/App/ttaccessible/AppKit/AppDelegate+NewInstance.swift
@@ -1,0 +1,137 @@
+//
+//  AppDelegate+NewInstance.swift
+//  ttaccessible
+//
+
+import AppKit
+
+@MainActor
+extension AppDelegate {
+    /// Show the picker that lets the user launch a separate process bound to
+    /// another profile. Triggered from the "New Instance…" menu item.
+    func openNewInstanceDialog() {
+        let registry = ProfileRegistry.shared
+        let existing = registry.listAll()
+        let currentSlug = ProfileContext.current.slug
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = L10n.text("profile.newInstance.title")
+        alert.informativeText = L10n.text("profile.newInstance.message")
+        alert.addButton(withTitle: L10n.text("profile.newInstance.launch"))
+        alert.addButton(withTitle: L10n.text("profile.newInstance.createNew"))
+        alert.addButton(withTitle: L10n.text("common.cancel"))
+
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 320, height: 26), pullsDown: false)
+        popup.setAccessibilityLabel(L10n.text("profile.newInstance.picker.accessibilityLabel"))
+        for entry in existing {
+            let title: String
+            if entry.slug == currentSlug {
+                title = L10n.format("profile.newInstance.picker.currentSuffix", entry.displayName)
+            } else {
+                title = entry.displayName
+            }
+            popup.addItem(withTitle: title)
+            popup.lastItem?.representedObject = entry.slug
+        }
+        if popup.numberOfItems == 0 {
+            // Should never happen — the registry always includes the default entry.
+            popup.addItem(withTitle: ProfileContext.defaultDisplayName)
+            popup.lastItem?.representedObject = ProfileContext.defaultSlug
+        }
+
+        // Default the picker to the first non-current profile if any exist.
+        if let firstOther = existing.firstIndex(where: { $0.slug != currentSlug }) {
+            popup.selectItem(at: firstOther)
+        }
+
+        alert.accessoryView = popup
+
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            guard let slug = popup.selectedItem?.representedObject as? String else { return }
+            launchInstance(forSlug: slug)
+        case .alertSecondButtonReturn:
+            promptCreateAndLaunchProfile()
+        default:
+            return
+        }
+    }
+
+    private func promptCreateAndLaunchProfile() {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = L10n.text("profile.create.title")
+        alert.informativeText = L10n.text("profile.create.message")
+        alert.addButton(withTitle: L10n.text("profile.create.launch"))
+        alert.addButton(withTitle: L10n.text("common.cancel"))
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        field.placeholderString = L10n.text("profile.create.placeholder")
+        field.setAccessibilityLabel(L10n.text("profile.create.field.accessibilityLabel"))
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let rawName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard rawName.isEmpty == false else {
+            presentNewInstanceError(message: L10n.text("profile.create.error.empty"))
+            return
+        }
+
+        let slug = ProfileContext.normalizeSlug(rawName)
+        guard slug.isEmpty == false else {
+            presentNewInstanceError(message: L10n.text("profile.create.error.invalid"))
+            return
+        }
+        guard slug != ProfileContext.defaultSlug else {
+            presentNewInstanceError(message: L10n.text("profile.create.error.reservedDefault"))
+            return
+        }
+
+        guard let entry = ProfileRegistry.shared.register(displayName: rawName) else {
+            presentNewInstanceError(message: L10n.text("profile.create.error.invalid"))
+            return
+        }
+        launchInstance(forSlug: entry.slug)
+    }
+
+    private func launchInstance(forSlug rawSlug: String) {
+        let slug = ProfileContext.normalizeSlug(rawSlug)
+
+        // Launching another process bound to the same profile would have two
+        // processes writing into the same UserDefaults suite — that's almost
+        // always a mistake, especially for the Default profile, which IS the
+        // current process. Refuse instead of silently double-launching.
+        if slug == ProfileContext.current.slug {
+            presentNewInstanceError(message: L10n.format(
+                "profile.newInstance.error.sameProfile",
+                ProfileContext.current.displayName
+            ))
+            return
+        }
+
+        let bundleURL = Bundle.main.bundleURL
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+        configuration.activates = true
+        configuration.arguments = ["-profile", slug]
+
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { [weak self] _, error in
+            guard let error else { return }
+            DispatchQueue.main.async {
+                self?.presentNewInstanceError(message: error.localizedDescription)
+            }
+        }
+    }
+
+    private func presentNewInstanceError(message: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = L10n.text("profile.newInstance.error.title")
+        alert.informativeText = message
+        alert.runModal()
+    }
+}

--- a/App/ttaccessible/AppKit/AppDelegate+NewInstance.swift
+++ b/App/ttaccessible/AppKit/AppDelegate+NewInstance.swift
@@ -59,6 +59,54 @@ extension AppDelegate {
         }
     }
 
+    /// Show the picker that lets the user rename or delete an existing custom
+    /// profile. Triggered from the "Manage Profiles…" menu item.
+    func openManageProfilesDialog() {
+        let registry = ProfileRegistry.shared
+        let custom = registry.customProfiles()
+
+        guard custom.isEmpty == false else {
+            let alert = NSAlert()
+            alert.alertStyle = .informational
+            alert.messageText = L10n.text("profile.manage.title")
+            alert.informativeText = L10n.text("profile.manage.empty.message")
+            alert.addButton(withTitle: L10n.text("common.ok"))
+            alert.runModal()
+            return
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = L10n.text("profile.manage.title")
+        alert.informativeText = L10n.text("profile.manage.message")
+        alert.addButton(withTitle: L10n.text("profile.manage.rename"))
+        alert.addButton(withTitle: L10n.text("profile.manage.delete"))
+        alert.addButton(withTitle: L10n.text("common.cancel"))
+
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 320, height: 26), pullsDown: false)
+        popup.setAccessibilityLabel(L10n.text("profile.manage.picker.accessibilityLabel"))
+        for entry in custom {
+            popup.addItem(withTitle: entry.displayName)
+            popup.lastItem?.representedObject = entry.slug
+        }
+        alert.accessoryView = popup
+
+        let response = alert.runModal()
+        guard let slug = popup.selectedItem?.representedObject as? String,
+              let entry = custom.first(where: { $0.slug == slug }) else {
+            return
+        }
+
+        switch response {
+        case .alertFirstButtonReturn:
+            promptRenameProfile(entry)
+        case .alertSecondButtonReturn:
+            promptDeleteProfile(entry)
+        default:
+            return
+        }
+    }
+
     private func promptCreateAndLaunchProfile() {
         let alert = NSAlert()
         alert.alertStyle = .informational
@@ -98,6 +146,69 @@ extension AppDelegate {
         launchInstance(forSlug: entry.slug)
     }
 
+    private func promptRenameProfile(_ entry: ProfileRegistry.Entry) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = L10n.text("profile.rename.title")
+        alert.informativeText = L10n.format("profile.rename.message", entry.displayName)
+        alert.addButton(withTitle: L10n.text("profile.rename.confirm"))
+        alert.addButton(withTitle: L10n.text("common.cancel"))
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 24))
+        field.stringValue = entry.displayName
+        field.placeholderString = L10n.text("profile.create.placeholder")
+        field.setAccessibilityLabel(L10n.text("profile.create.field.accessibilityLabel"))
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let newName = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard newName.isEmpty == false else {
+            presentNewInstanceError(message: L10n.text("profile.create.error.empty"))
+            return
+        }
+        if newName == entry.displayName {
+            return
+        }
+        guard ProfileRegistry.shared.rename(slug: entry.slug, to: newName) != nil else {
+            presentNewInstanceError(message: L10n.text("profile.rename.error.failed"))
+            return
+        }
+    }
+
+    private func promptDeleteProfile(_ entry: ProfileRegistry.Entry) {
+        if entry.slug == ProfileContext.current.slug {
+            presentNewInstanceError(message: L10n.format(
+                "profile.delete.error.currentRunning",
+                entry.displayName
+            ))
+            return
+        }
+        if ProfileInstanceLock.isAnotherInstanceRunning(forSlug: entry.slug) {
+            presentNewInstanceError(message: L10n.format(
+                "profile.delete.error.otherInstanceRunning",
+                entry.displayName
+            ))
+            return
+        }
+
+        let confirm = NSAlert()
+        confirm.alertStyle = .warning
+        confirm.messageText = L10n.format("profile.delete.confirm.title", entry.displayName)
+        confirm.informativeText = L10n.text("profile.delete.confirm.message")
+        confirm.addButton(withTitle: L10n.text("profile.delete.confirm.button"))
+        confirm.addButton(withTitle: L10n.text("common.cancel"))
+        // Make Cancel the default Return action so an accidental Enter doesn't
+        // wipe the profile.
+        confirm.buttons.first?.keyEquivalent = ""
+        confirm.buttons.last?.keyEquivalent = "\r"
+        guard confirm.runModal() == .alertFirstButtonReturn else { return }
+
+        ProfileContext.purgeStorage(forSlug: entry.slug)
+        ProfileRegistry.shared.remove(slug: entry.slug)
+    }
+
     private func launchInstance(forSlug rawSlug: String) {
         let slug = ProfileContext.normalizeSlug(rawSlug)
 
@@ -109,6 +220,19 @@ extension AppDelegate {
             presentNewInstanceError(message: L10n.format(
                 "profile.newInstance.error.sameProfile",
                 ProfileContext.current.displayName
+            ))
+            return
+        }
+
+        // Cross-process check: another instance may already be running this
+        // slug. Best-effort PID-file lock — see ProfileInstanceLock for the
+        // limitations (stale-on-crash + PID recycling).
+        if ProfileInstanceLock.isAnotherInstanceRunning(forSlug: slug) {
+            let entry = ProfileRegistry.shared.entry(forSlug: slug)
+            let name = entry?.displayName ?? slug
+            presentNewInstanceError(message: L10n.format(
+                "profile.newInstance.error.alreadyRunning",
+                name
             ))
             return
         }

--- a/App/ttaccessible/AppKit/FeedbackWindowController.swift
+++ b/App/ttaccessible/AppKit/FeedbackWindowController.swift
@@ -52,7 +52,7 @@ private struct FeedbackView: View {
     private static let savedEmailKey = "appBackendFeedbackEmail"
 
     @State private var contactType: AppBackendClient.ContactType = .bug
-    @State private var email = UserDefaults.standard.string(forKey: FeedbackView.savedEmailKey) ?? ""
+    @State private var email = ProfileContext.current.userDefaults.string(forKey: FeedbackView.savedEmailKey) ?? ""
     @State private var message = ""
     @State private var attachAudioLog = true
     @State private var isSending = false
@@ -154,7 +154,7 @@ private struct FeedbackView: View {
             isSending = false
             switch result {
             case .success:
-                UserDefaults.standard.set(trimmedEmail, forKey: FeedbackView.savedEmailKey)
+                ProfileContext.current.userDefaults.set(trimmedEmail, forKey: FeedbackView.savedEmailKey)
                 isShowingSuccess = true
             case .failure(let error):
                 sendErrorMessage = error.localizedMessage

--- a/App/ttaccessible/AppKit/SavedServersWindowController.swift
+++ b/App/ttaccessible/AppKit/SavedServersWindowController.swift
@@ -20,7 +20,7 @@ final class SavedServersWindowController: NSWindowController {
             backing: .buffered,
             defer: false
         )
-        window.title = L10n.text("savedServers.window.title")
+        window.title = ProfileContext.current.decorateWindowTitle(L10n.text("savedServers.window.title"))
         window.center()
         window.minSize = NSSize(width: 680, height: 420)
         window.setFrameAutosaveName("SavedServersWindow")

--- a/App/ttaccessible/Models/ProfileContext.swift
+++ b/App/ttaccessible/Models/ProfileContext.swift
@@ -1,0 +1,167 @@
+//
+//  ProfileContext.swift
+//  ttaccessible
+//
+
+import Foundation
+
+/// Identifies a single profile (instance) of ttaccessible. Each profile gets
+/// its own UserDefaults suite, Application Support subdirectory, and keychain
+/// service namespace so two instances of the app can run side-by-side without
+/// sharing any state.
+///
+/// The "default" profile maps to `UserDefaults.standard` and the existing
+/// Application Support paths so pre-profile installs keep working with no
+/// migration.
+final class ProfileContext {
+    static let defaultSlug = "default"
+    static let defaultDisplayName = "Default"
+
+    /// The active profile for this process. Resolved lazily on first access
+    /// from `-profile <slug>` in `CommandLine.arguments`; stores that take a
+    /// `UserDefaults` argument default to `ProfileContext.current.userDefaults`,
+    /// which triggers that first access before any store is constructed.
+    static var current: ProfileContext = ProfileContext.resolveFromLaunchEnvironment()
+
+    /// Look up `-profile <slug>` in `CommandLine.arguments`, fall back to
+    /// `TTACCESSIBLE_PROFILE` in the environment for sandbox-friendly
+    /// scripted launches. Unknown slugs are registered on the fly so a freshly
+    /// chosen profile works on its very first launch.
+    private static func resolveFromLaunchEnvironment() -> ProfileContext {
+        let args = CommandLine.arguments
+        var requestedSlug: String?
+        var i = 1
+        while i < args.count {
+            if args[i] == "-profile" || args[i] == "--profile" {
+                if i + 1 < args.count {
+                    requestedSlug = args[i + 1]
+                }
+                break
+            }
+            i += 1
+        }
+        if requestedSlug == nil {
+            if let envSlug = ProcessInfo.processInfo.environment["TTACCESSIBLE_PROFILE"],
+               envSlug.isEmpty == false {
+                requestedSlug = envSlug
+            }
+        }
+        guard let rawSlug = requestedSlug else {
+            return defaultProfile()
+        }
+        let slug = normalizeSlug(rawSlug)
+        guard slug.isEmpty == false, slug != defaultSlug else {
+            return defaultProfile()
+        }
+        let registry = ProfileRegistry.shared
+        let displayName: String
+        if let existing = registry.entry(forSlug: slug) {
+            displayName = existing.displayName
+        } else {
+            let registered = registry.register(displayName: rawSlug)
+            displayName = registered?.displayName ?? rawSlug
+        }
+        return make(slug: slug, displayName: displayName)
+    }
+
+    let slug: String
+    let displayName: String
+    let userDefaults: UserDefaults
+    let isDefault: Bool
+
+    private init(slug: String, displayName: String, userDefaults: UserDefaults, isDefault: Bool) {
+        self.slug = slug
+        self.displayName = displayName
+        self.userDefaults = userDefaults
+        self.isDefault = isDefault
+    }
+
+    static func defaultProfile() -> ProfileContext {
+        ProfileContext(
+            slug: defaultSlug,
+            displayName: defaultDisplayName,
+            userDefaults: .standard,
+            isDefault: true
+        )
+    }
+
+    static func make(slug rawSlug: String, displayName: String) -> ProfileContext {
+        let normalized = normalizeSlug(rawSlug)
+        guard normalized != defaultSlug, normalized.isEmpty == false else {
+            return defaultProfile()
+        }
+        let suiteName = "com.math65.ttaccessible.profile.\(normalized)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        let trimmedDisplay = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ProfileContext(
+            slug: normalized,
+            displayName: trimmedDisplay.isEmpty ? normalized : trimmedDisplay,
+            userDefaults: defaults,
+            isDefault: false
+        )
+    }
+
+    /// Sanitize a user-supplied profile name into a slug usable as a UserDefaults
+    /// suite name, directory name, and keychain service suffix.
+    static func normalizeSlug(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789-_")
+        let scalars = trimmed.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let collapsed = String(scalars)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        return collapsed
+    }
+
+    // MARK: - Paths
+
+    /// Application Support directory specific to this profile. Custom profiles
+    /// get a per-slug subdirectory; the default profile uses the user's
+    /// Application Support root so pre-existing data stays in place.
+    var applicationSupportRoot: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+        if isDefault {
+            return base
+        }
+        return base
+            .appendingPathComponent("ttaccessible", isDirectory: true)
+            .appendingPathComponent("profiles", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+    }
+
+    /// Where custom sound packs are stored. The default profile keeps the
+    /// historical `~/Library/Application Support/Sound Packs/` location.
+    var customSoundPacksDirectory: URL {
+        applicationSupportRoot.appendingPathComponent("Sound Packs", isDirectory: true)
+    }
+
+    /// Where channel chat history JSON files live. The default profile keeps
+    /// the historical `~/Library/Application Support/ttaccessible/history/`
+    /// location.
+    var channelChatHistoryDirectory: URL {
+        if isDefault {
+            return applicationSupportRoot
+                .appendingPathComponent("ttaccessible", isDirectory: true)
+                .appendingPathComponent("history", isDirectory: true)
+        }
+        return applicationSupportRoot.appendingPathComponent("history", isDirectory: true)
+    }
+
+    /// Keychain `kSecAttrService` used by `ServerPasswordStore`. Per-profile so
+    /// custom profiles get a fresh keychain namespace and don't collide with
+    /// the default profile's items.
+    /// Decorate a window title with the active profile name when not running
+    /// the default profile, so users can tell two running instances apart.
+    func decorateWindowTitle(_ base: String) -> String {
+        guard isDefault == false else { return base }
+        return "\(base) — \(displayName)"
+    }
+
+    var keychainServiceName: String {
+        if isDefault {
+            return "com.math65.ttaccessible.saved-server-password"
+        }
+        return "com.math65.ttaccessible.saved-server-password.profile.\(slug)"
+    }
+}

--- a/App/ttaccessible/Models/ProfileContext.swift
+++ b/App/ttaccessible/Models/ProfileContext.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import Security
 
 /// Identifies a single profile (instance) of ttaccessible. Each profile gets
 /// its own UserDefaults suite, Application Support subdirectory, and keychain
@@ -21,7 +22,10 @@ final class ProfileContext {
     /// from `-profile <slug>` in `CommandLine.arguments`; stores that take a
     /// `UserDefaults` argument default to `ProfileContext.current.userDefaults`,
     /// which triggers that first access before any store is constructed.
-    static var current: ProfileContext = ProfileContext.resolveFromLaunchEnvironment()
+    ///
+    /// Bound for the lifetime of the process — switching profiles means
+    /// launching a new instance with `NSWorkspace.openApplication`.
+    static let current: ProfileContext = ProfileContext.resolveFromLaunchEnvironment()
 
     /// Look up `-profile <slug>` in `CommandLine.arguments`, fall back to
     /// `TTACCESSIBLE_PROFILE` in the environment for sandbox-friendly
@@ -90,7 +94,7 @@ final class ProfileContext {
         guard normalized != defaultSlug, normalized.isEmpty == false else {
             return defaultProfile()
         }
-        let suiteName = "com.math65.ttaccessible.profile.\(normalized)"
+        let suiteName = suiteName(forSlug: normalized)
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard
         let trimmedDisplay = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         return ProfileContext(
@@ -118,9 +122,13 @@ final class ProfileContext {
     /// Application Support directory specific to this profile. Custom profiles
     /// get a per-slug subdirectory; the default profile uses the user's
     /// Application Support root so pre-existing data stays in place.
+    ///
+    /// Note: under the App Sandbox this resolves inside the container
+    /// (`~/Library/Containers/com.math65.ttaccessible/Data/Library/Application Support/`),
+    /// not the user's literal `~/Library/Application Support/`. Either way,
+    /// every instance of the bundle sees the same root.
     var applicationSupportRoot: URL {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+        let base = ProfileContext.applicationSupportBase
         if isDefault {
             return base
         }
@@ -151,6 +159,10 @@ final class ProfileContext {
     /// Keychain `kSecAttrService` used by `ServerPasswordStore`. Per-profile so
     /// custom profiles get a fresh keychain namespace and don't collide with
     /// the default profile's items.
+    var keychainServiceName: String {
+        Self.keychainServiceName(forSlug: slug, isDefault: isDefault)
+    }
+
     /// Decorate a window title with the active profile name when not running
     /// the default profile, so users can tell two running instances apart.
     func decorateWindowTitle(_ base: String) -> String {
@@ -158,10 +170,71 @@ final class ProfileContext {
         return "\(base) — \(displayName)"
     }
 
-    var keychainServiceName: String {
-        if isDefault {
+    // MARK: - Shared helpers
+
+    /// Base Application Support directory visible to every instance of the
+    /// bundle regardless of which profile that instance is bound to.
+    static var applicationSupportBase: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+    }
+
+    /// Directory used for cross-instance coordination (e.g. running-profile
+    /// PID locks). Always under `…/Application Support/ttaccessible/`, never
+    /// inside a per-profile subdirectory, so all instances find the same path.
+    static var sharedCoordinationDirectory: URL {
+        applicationSupportBase
+            .appendingPathComponent("ttaccessible", isDirectory: true)
+            .appendingPathComponent("instance-locks", isDirectory: true)
+    }
+
+    static func suiteName(forSlug slug: String) -> String {
+        "com.math65.ttaccessible.profile.\(slug)"
+    }
+
+    static func keychainServiceName(forSlug slug: String, isDefault: Bool) -> String {
+        if isDefault || slug == defaultSlug {
             return "com.math65.ttaccessible.saved-server-password"
         }
         return "com.math65.ttaccessible.saved-server-password.profile.\(slug)"
+    }
+
+    /// Tear down every storage location owned by a profile. Used by the
+    /// Manage Profiles UI when the user deletes a profile. Refuses to touch
+    /// the default profile.
+    @discardableResult
+    static func purgeStorage(forSlug rawSlug: String) -> Bool {
+        let slug = normalizeSlug(rawSlug)
+        guard slug.isEmpty == false, slug != defaultSlug else {
+            return false
+        }
+
+        // Application Support subdirectory (sound packs, chat history, …).
+        let profileRoot = applicationSupportBase
+            .appendingPathComponent("ttaccessible", isDirectory: true)
+            .appendingPathComponent("profiles", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+        try? FileManager.default.removeItem(at: profileRoot)
+
+        // UserDefaults suite.
+        let suite = suiteName(forSlug: slug)
+        UserDefaults.standard.removePersistentDomain(forName: suite)
+        UserDefaults.standard.synchronize()
+        // Belt-and-braces: also remove the suite-backed plist if it lingers
+        // (older macOS bug where removePersistentDomain didn't always delete
+        // the file).
+        UserDefaults().removePersistentDomain(forName: suite)
+
+        // Keychain items under this profile's service.
+        let service = keychainServiceName(forSlug: slug, isDefault: false)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        // errSecItemNotFound is fine — nothing was ever stored for this slug.
+        _ = status
+
+        return true
     }
 }

--- a/App/ttaccessible/Services/AnnouncementService.swift
+++ b/App/ttaccessible/Services/AnnouncementService.swift
@@ -30,7 +30,7 @@ final class AnnouncementService {
     }
 
     private func presentIfNeeded(_ announcement: AppBackendClient.Announcement) {
-        let defaults = UserDefaults.standard
+        let defaults = ProfileContext.current.userDefaults
         var seenIDs = defaults.stringArray(forKey: Self.seenAnnouncementIDsKey) ?? []
         if announcement.mode == "once", seenIDs.contains(announcement.id) {
             return
@@ -53,7 +53,7 @@ final class AnnouncementService {
     /// Stable per-install UUID. The server only stores a hash of it, for
     /// deduplicating the announcement reach counter.
     private static var installID: String {
-        let defaults = UserDefaults.standard
+        let defaults = ProfileContext.current.userDefaults
         if let existing = defaults.string(forKey: installIDKey), existing.isEmpty == false {
             return existing
         }

--- a/App/ttaccessible/Services/AppPreferencesStore.swift
+++ b/App/ttaccessible/Services/AppPreferencesStore.swift
@@ -21,7 +21,7 @@ final class AppPreferencesStore: ObservableObject {
     private let decoder = JSONDecoder()
     private var pendingPersistWorkItem: DispatchWorkItem?
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = ProfileContext.current.userDefaults) {
         self.userDefaults = userDefaults
 
         if let data = userDefaults.data(forKey: Keys.preferences),

--- a/App/ttaccessible/Services/AudioLogger.swift
+++ b/App/ttaccessible/Services/AudioLogger.swift
@@ -10,7 +10,13 @@ enum AudioLogger {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/TTAccessible", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent("audio.log")
+        // The default profile keeps the historical `audio.log` filename. Other
+        // profiles get `audio-<slug>.log` so two instances don't overwrite
+        // each other's log on launch (and so the feedback bug-report attaches
+        // the right one).
+        let profile = ProfileContext.current
+        let fileName = profile.isDefault ? "audio.log" : "audio-\(profile.slug).log"
+        return dir.appendingPathComponent(fileName)
     }()
 
     private static let queue = DispatchQueue(label: "com.ttaccessible.audiologger")

--- a/App/ttaccessible/Services/ChannelChatHistoryStore.swift
+++ b/App/ttaccessible/Services/ChannelChatHistoryStore.swift
@@ -10,8 +10,7 @@ final class ChannelChatHistoryStore {
     private let fileManager = FileManager.default
 
     private var storageDirectory: URL? {
-        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
-            .appendingPathComponent("ttaccessible/history", isDirectory: true)
+        ProfileContext.current.channelChatHistoryDirectory
     }
 
     func load(forKey key: String) -> [ChannelChatMessage] {

--- a/App/ttaccessible/Services/LastChannelStore.swift
+++ b/App/ttaccessible/Services/LastChannelStore.swift
@@ -9,7 +9,7 @@ final class LastChannelStore {
     private let key = "lastChannelPathByServer"
     private let defaults: UserDefaults
 
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = ProfileContext.current.userDefaults) {
         self.defaults = defaults
     }
 

--- a/App/ttaccessible/Services/ProfileInstanceLock.swift
+++ b/App/ttaccessible/Services/ProfileInstanceLock.swift
@@ -1,0 +1,79 @@
+//
+//  ProfileInstanceLock.swift
+//  ttaccessible
+//
+
+import Darwin
+import Foundation
+
+/// Best-effort tracker for "which profile is already running in another
+/// process." Each instance writes its PID to a per-slug file at launch and
+/// removes it on graceful exit; the "New Instance" menu consults these files
+/// before launching to refuse a second instance of the same profile.
+///
+/// Limitations:
+/// - Crashes leave a stale PID file. Resolved on next check via `kill(pid, 0)`
+///   liveness probe; if the original process is gone, the lock is treated as
+///   free and overwritten.
+/// - PID recycling is theoretically possible (a stale PID could be reused by
+///   an unrelated process) — extremely unlikely on macOS within the
+///   typical app session, and worst case the user sees a false "already
+///   running" refusal and can remove the lock file manually.
+/// - Two processes acquiring at exactly the same instant race; both succeed.
+///   Not a correctness problem — UserDefaults writes are last-writer-wins per
+///   key, which the per-profile isolation already tolerates.
+enum ProfileInstanceLock {
+    private static let queue = DispatchQueue(label: "com.math65.ttaccessible.profilelock")
+
+    /// Write the current process's PID to this profile's lock file.
+    static func acquire(for context: ProfileContext) {
+        queue.async {
+            let url = lockFileURL(forSlug: context.slug)
+            let dir = url.deletingLastPathComponent()
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let pid = ProcessInfo.processInfo.processIdentifier
+            let body = "\(pid)\n"
+            try? body.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    /// Remove this profile's lock file. Safe to call multiple times.
+    static func release(for context: ProfileContext) {
+        // Synchronous so it runs inside `applicationWillTerminate` before
+        // the process actually exits.
+        let url = lockFileURL(forSlug: context.slug)
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Returns true if another live process holds the lock for the given
+    /// profile slug. Stale locks (file present but PID dead) are cleared and
+    /// reported as not-running.
+    static func isAnotherInstanceRunning(forSlug rawSlug: String) -> Bool {
+        let slug = ProfileContext.normalizeSlug(rawSlug)
+        guard slug.isEmpty == false else { return false }
+        let url = lockFileURL(forSlug: slug)
+        guard let contents = try? String(contentsOf: url, encoding: .utf8),
+              let pid = Int32(contents.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return false
+        }
+        // kill(pid, 0) is the standard liveness probe: returns 0 if signalable,
+        // -1 with errno == ESRCH if no such process.
+        if kill(pid, 0) == 0 {
+            // Don't refuse on ourselves — same PID means a relaunch that
+            // didn't get a chance to release first.
+            if pid == ProcessInfo.processInfo.processIdentifier {
+                return false
+            }
+            return true
+        }
+        // Stale lock — file present but the PID is gone. Clean it up so the
+        // next launch starts fresh.
+        try? FileManager.default.removeItem(at: url)
+        return false
+    }
+
+    private static func lockFileURL(forSlug slug: String) -> URL {
+        ProfileContext.sharedCoordinationDirectory
+            .appendingPathComponent("\(slug).pid", isDirectory: false)
+    }
+}

--- a/App/ttaccessible/Services/ProfileRegistry.swift
+++ b/App/ttaccessible/Services/ProfileRegistry.swift
@@ -8,6 +8,12 @@ import Foundation
 /// Tracks the set of profiles known to ttaccessible. The registry lives in a
 /// dedicated UserDefaults suite that every running instance can read, so a
 /// profile created in one instance shows up in another's picker immediately.
+///
+/// Mutating calls hold an in-process lock and force the suite to sync after
+/// writing. Cross-process simultaneous registrations could still race (two
+/// instances each reading the suite, modifying, and writing back) — that's
+/// inherent to UserDefaults and tolerable here because registrations are
+/// user-initiated and rare.
 final class ProfileRegistry {
     struct Entry: Codable, Equatable {
         var slug: String
@@ -21,6 +27,7 @@ final class ProfileRegistry {
     }
 
     private let defaults: UserDefaults
+    private let lock = NSLock()
 
     init(defaults: UserDefaults = ProfileRegistry.makeSharedDefaults()) {
         self.defaults = defaults
@@ -68,17 +75,71 @@ final class ProfileRegistry {
         let slug = ProfileContext.normalizeSlug(trimmed)
         guard slug.isEmpty == false, slug != ProfileContext.defaultSlug else { return nil }
 
-        var entries = loadCustomEntries()
+        lock.lock()
+        defer { lock.unlock() }
+
+        var entries = loadCustomEntriesLocked()
         if let existing = entries.first(where: { $0.slug == slug }) {
             return existing
         }
         let entry = Entry(slug: slug, displayName: trimmed)
         entries.append(entry)
-        persist(entries)
+        persistLocked(entries)
         return entry
     }
 
+    /// Update the display name of an existing custom profile. The slug stays
+    /// the same (it identifies on-disk paths and keychain items). Returns the
+    /// updated entry on success.
+    @discardableResult
+    func rename(slug rawSlug: String, to rawName: String) -> Entry? {
+        let slug = ProfileContext.normalizeSlug(rawSlug)
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard slug.isEmpty == false, slug != ProfileContext.defaultSlug, trimmed.isEmpty == false else {
+            return nil
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        var entries = loadCustomEntriesLocked()
+        guard let index = entries.firstIndex(where: { $0.slug == slug }) else {
+            return nil
+        }
+        entries[index].displayName = trimmed
+        persistLocked(entries)
+        return entries[index]
+    }
+
+    /// Drop the registry entry for a custom profile. Does NOT touch the
+    /// on-disk data, UserDefaults suite, or keychain items — call
+    /// `ProfileContext.purgeStorage(forSlug:)` for that. Returns true if an
+    /// entry was removed.
+    @discardableResult
+    func remove(slug rawSlug: String) -> Bool {
+        let slug = ProfileContext.normalizeSlug(rawSlug)
+        guard slug.isEmpty == false, slug != ProfileContext.defaultSlug else { return false }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        var entries = loadCustomEntriesLocked()
+        let before = entries.count
+        entries.removeAll { $0.slug == slug }
+        guard entries.count != before else { return false }
+        persistLocked(entries)
+        return true
+    }
+
+    // MARK: - Storage
+
     private func loadCustomEntries() -> [Entry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadCustomEntriesLocked()
+    }
+
+    private func loadCustomEntriesLocked() -> [Entry] {
         guard let data = defaults.data(forKey: Keys.entries),
               let decoded = try? JSONDecoder().decode([Entry].self, from: data) else {
             return []
@@ -86,8 +147,9 @@ final class ProfileRegistry {
         return decoded.filter { $0.slug != ProfileContext.defaultSlug }
     }
 
-    private func persist(_ entries: [Entry]) {
+    private func persistLocked(_ entries: [Entry]) {
         guard let data = try? JSONEncoder().encode(entries) else { return }
         defaults.set(data, forKey: Keys.entries)
+        defaults.synchronize()
     }
 }

--- a/App/ttaccessible/Services/ProfileRegistry.swift
+++ b/App/ttaccessible/Services/ProfileRegistry.swift
@@ -1,0 +1,93 @@
+//
+//  ProfileRegistry.swift
+//  ttaccessible
+//
+
+import Foundation
+
+/// Tracks the set of profiles known to ttaccessible. The registry lives in a
+/// dedicated UserDefaults suite that every running instance can read, so a
+/// profile created in one instance shows up in another's picker immediately.
+final class ProfileRegistry {
+    struct Entry: Codable, Equatable {
+        var slug: String
+        var displayName: String
+    }
+
+    static let shared = ProfileRegistry()
+
+    private enum Keys {
+        static let entries = "profiles.registry.entries"
+    }
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = ProfileRegistry.makeSharedDefaults()) {
+        self.defaults = defaults
+    }
+
+    static func makeSharedDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "com.math65.ttaccessible.profiles") ?? .standard
+    }
+
+    /// All profiles known to the app, including the synthetic "Default" entry.
+    /// Sorted by display name (default first).
+    func listAll() -> [Entry] {
+        let custom = loadCustomEntries()
+        let defaultEntry = Entry(slug: ProfileContext.defaultSlug, displayName: ProfileContext.defaultDisplayName)
+        return [defaultEntry] + custom.sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    /// Custom (non-default) profiles only.
+    func customProfiles() -> [Entry] {
+        loadCustomEntries().sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    /// Look up a profile by slug. Returns the synthetic default entry for the
+    /// default slug; nil for unknown slugs.
+    func entry(forSlug slug: String) -> Entry? {
+        let normalized = ProfileContext.normalizeSlug(slug)
+        if normalized == ProfileContext.defaultSlug {
+            return Entry(slug: ProfileContext.defaultSlug, displayName: ProfileContext.defaultDisplayName)
+        }
+        return loadCustomEntries().first { $0.slug == normalized }
+    }
+
+    /// Register a new profile with the given display name. The display name is
+    /// sanitized into a slug; if a profile with that slug already exists, this
+    /// is a no-op and the existing entry is returned. Returns nil if the input
+    /// is empty or collides with the reserved default slug.
+    @discardableResult
+    func register(displayName rawName: String) -> Entry? {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return nil }
+        let slug = ProfileContext.normalizeSlug(trimmed)
+        guard slug.isEmpty == false, slug != ProfileContext.defaultSlug else { return nil }
+
+        var entries = loadCustomEntries()
+        if let existing = entries.first(where: { $0.slug == slug }) {
+            return existing
+        }
+        let entry = Entry(slug: slug, displayName: trimmed)
+        entries.append(entry)
+        persist(entries)
+        return entry
+    }
+
+    private func loadCustomEntries() -> [Entry] {
+        guard let data = defaults.data(forKey: Keys.entries),
+              let decoded = try? JSONDecoder().decode([Entry].self, from: data) else {
+            return []
+        }
+        return decoded.filter { $0.slug != ProfileContext.defaultSlug }
+    }
+
+    private func persist(_ entries: [Entry]) {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        defaults.set(data, forKey: Keys.entries)
+    }
+}

--- a/App/ttaccessible/Services/SavedServerStore.swift
+++ b/App/ttaccessible/Services/SavedServerStore.swift
@@ -20,7 +20,7 @@ final class SavedServerStore {
     private var cachedSelectedID: UUID?
     private var pendingPersistWorkItem: DispatchWorkItem?
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = ProfileContext.current.userDefaults) {
         self.userDefaults = userDefaults
         if let data = userDefaults.data(forKey: Keys.records),
            let decoded = try? decoder.decode([SavedServerRecord].self, from: data) {

--- a/App/ttaccessible/Services/ServerPasswordStore.swift
+++ b/App/ttaccessible/Services/ServerPasswordStore.swift
@@ -70,8 +70,8 @@ final class ServerPasswordStore {
     private static let cleanupDoneKey = "ServerPasswordStore.dpkResetCompleted.v3"
 
     init(
-        serviceName: String = "com.math65.ttaccessible.saved-server-password",
-        defaults: UserDefaults = .standard
+        serviceName: String = ProfileContext.current.keychainServiceName,
+        defaults: UserDefaults = ProfileContext.current.userDefaults
     ) {
         self.serviceName = serviceName
         self.defaults = defaults

--- a/App/ttaccessible/Services/SoundPlayer.swift
+++ b/App/ttaccessible/Services/SoundPlayer.swift
@@ -49,7 +49,7 @@ final class SoundPlayer {
     private static let deletedBuiltInPacksKey = "soundPlayer.deletedBuiltInPacks"
 
     static var availablePacks: [String] {
-        let deletedBuiltInPacks = Set(UserDefaults.standard.stringArray(forKey: deletedBuiltInPacksKey) ?? [])
+        let deletedBuiltInPacks = Set(ProfileContext.current.userDefaults.stringArray(forKey: deletedBuiltInPacksKey) ?? [])
         let bundled = builtInPacks.filter { !deletedBuiltInPacks.contains($0) }
         let custom = customPackDirectories().map(\.lastPathComponent)
         return Set(bundled + custom).sorted {
@@ -58,9 +58,7 @@ final class SoundPlayer {
     }
 
     static var customSoundPacksDirectory: URL {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
-        return base.appendingPathComponent("Sound Packs", isDirectory: true)
+        ProfileContext.current.customSoundPacksDirectory
     }
 
     private var players: [NotificationSound: AVAudioPlayer] = [:]
@@ -158,9 +156,10 @@ final class SoundPlayer {
         if isCustomPack(packName) {
             try FileManager.default.removeItem(at: customPackDirectory(named: packName))
         } else if builtInPacks.contains(packName) {
-            var deletedBuiltInPacks = Set(UserDefaults.standard.stringArray(forKey: deletedBuiltInPacksKey) ?? [])
+            let defaults = ProfileContext.current.userDefaults
+            var deletedBuiltInPacks = Set(defaults.stringArray(forKey: deletedBuiltInPacksKey) ?? [])
             deletedBuiltInPacks.insert(packName)
-            UserDefaults.standard.set(Array(deletedBuiltInPacks), forKey: deletedBuiltInPacksKey)
+            defaults.set(Array(deletedBuiltInPacks), forKey: deletedBuiltInPacksKey)
         }
     }
 

--- a/App/ttaccessible/Services/TeamTalkConfigAccessStore.swift
+++ b/App/ttaccessible/Services/TeamTalkConfigAccessStore.swift
@@ -14,7 +14,7 @@ final class TeamTalkConfigAccessStore {
 
     private let userDefaults: UserDefaults
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = ProfileContext.current.userDefaults) {
         self.userDefaults = userDefaults
     }
 

--- a/App/ttaccessible/Services/UserVolumeStore.swift
+++ b/App/ttaccessible/Services/UserVolumeStore.swift
@@ -10,7 +10,7 @@ final class UserVolumeStore {
     private let mediaFileKey = "userMediaFileVolumeByUsername"
     private let defaults: UserDefaults
 
-    init(defaults: UserDefaults = .standard) {
+    init(defaults: UserDefaults = ProfileContext.current.userDefaults) {
         self.defaults = defaults
     }
 

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -934,3 +934,21 @@
 "feedback.error.rateLimited" = "Too many messages were sent recently. Please try again in an hour.";
 "feedback.error.validation" = "Check that your email address is valid and the message is not empty.";
 "feedback.error.server" = "The server could not process the message. Please try again later.";
+
+"profile.menu.newInstance" = "New Instance…";
+"profile.newInstance.title" = "Open a new instance";
+"profile.newInstance.message" = "Choose a profile to launch as a separate instance. Each profile has its own servers, preferences, and settings, and runs side-by-side with the current one.";
+"profile.newInstance.launch" = "Launch";
+"profile.newInstance.createNew" = "New Profile…";
+"profile.newInstance.picker.accessibilityLabel" = "Profile to launch";
+"profile.newInstance.picker.currentSuffix" = "%@ (current)";
+"profile.newInstance.error.title" = "Could Not Launch Instance";
+"profile.newInstance.error.sameProfile" = "The profile \"%@\" is already running in this window. Pick a different profile, or create a new one.";
+"profile.create.title" = "Create a new profile";
+"profile.create.message" = "Enter a name for the new profile. A separate instance of ttaccessible will launch with its own settings and saved servers.";
+"profile.create.launch" = "Create & Launch";
+"profile.create.placeholder" = "Profile name";
+"profile.create.field.accessibilityLabel" = "Profile name";
+"profile.create.error.empty" = "Please enter a name for the profile.";
+"profile.create.error.invalid" = "The profile name doesn't contain any usable characters. Try a name with letters or numbers.";
+"profile.create.error.reservedDefault" = "The name \"Default\" is reserved. Please choose a different name.";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -952,3 +952,21 @@
 "profile.create.error.empty" = "Please enter a name for the profile.";
 "profile.create.error.invalid" = "The profile name doesn't contain any usable characters. Try a name with letters or numbers.";
 "profile.create.error.reservedDefault" = "The name \"Default\" is reserved. Please choose a different name.";
+
+"profile.menu.manage" = "Manage Profiles…";
+"profile.manage.title" = "Manage profiles";
+"profile.manage.message" = "Pick a profile, then choose Rename or Delete.";
+"profile.manage.empty.message" = "No custom profiles yet. Use New Instance… to create one.";
+"profile.manage.picker.accessibilityLabel" = "Profile to manage";
+"profile.manage.rename" = "Rename…";
+"profile.manage.delete" = "Delete…";
+"profile.rename.title" = "Rename profile";
+"profile.rename.message" = "Enter a new display name for \"%@\". The profile's data is not moved or duplicated.";
+"profile.rename.confirm" = "Rename";
+"profile.rename.error.failed" = "Could not rename the profile. Try again or restart the app.";
+"profile.delete.confirm.title" = "Delete the profile \"%@\"?";
+"profile.delete.confirm.message" = "This removes the profile from the picker and deletes its saved servers, preferences, sound packs, chat history, and stored passwords. This cannot be undone.";
+"profile.delete.confirm.button" = "Delete";
+"profile.delete.error.currentRunning" = "The profile \"%@\" is the one currently running in this window. Quit this instance first, then delete it from another instance.";
+"profile.delete.error.otherInstanceRunning" = "Another instance of ttaccessible is running with the profile \"%@\". Quit that instance first.";
+"profile.newInstance.error.alreadyRunning" = "Another instance of ttaccessible is already running with the profile \"%@\". Bring that window forward instead of launching a second copy.";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -952,3 +952,21 @@
 "profile.create.error.empty" = "Veuillez saisir un nom pour le profil.";
 "profile.create.error.invalid" = "Le nom du profil ne contient aucun caractère utilisable. Essayez un nom avec des lettres ou des chiffres.";
 "profile.create.error.reservedDefault" = "Le nom « Default » est réservé. Veuillez choisir un autre nom.";
+
+"profile.menu.manage" = "Gérer les profils…";
+"profile.manage.title" = "Gérer les profils";
+"profile.manage.message" = "Sélectionnez un profil, puis choisissez Renommer ou Supprimer.";
+"profile.manage.empty.message" = "Aucun profil personnalisé pour l'instant. Utilisez Nouvelle instance… pour en créer un.";
+"profile.manage.picker.accessibilityLabel" = "Profil à gérer";
+"profile.manage.rename" = "Renommer…";
+"profile.manage.delete" = "Supprimer…";
+"profile.rename.title" = "Renommer le profil";
+"profile.rename.message" = "Saisissez un nouveau nom à afficher pour « %@ ». Les données du profil ne sont ni déplacées, ni dupliquées.";
+"profile.rename.confirm" = "Renommer";
+"profile.rename.error.failed" = "Le profil n'a pas pu être renommé. Réessayez ou redémarrez l'application.";
+"profile.delete.confirm.title" = "Supprimer le profil « %@ » ?";
+"profile.delete.confirm.message" = "Cette action retire le profil du sélecteur et supprime ses serveurs enregistrés, ses préférences, ses packs sonores, son historique de discussion et ses mots de passe stockés. Cette action est irréversible.";
+"profile.delete.confirm.button" = "Supprimer";
+"profile.delete.error.currentRunning" = "Le profil « %@ » est celui en cours d'exécution dans cette fenêtre. Quittez d'abord cette instance, puis supprimez-le depuis une autre instance.";
+"profile.delete.error.otherInstanceRunning" = "Une autre instance de ttaccessible utilise déjà le profil « %@ ». Quittez-la d'abord.";
+"profile.newInstance.error.alreadyRunning" = "Une autre instance de ttaccessible utilise déjà le profil « %@ ». Mettez cette fenêtre au premier plan plutôt que d'en lancer une deuxième.";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -934,3 +934,21 @@
 "feedback.error.rateLimited" = "Trop de messages envoyés récemment. Veuillez réessayer dans une heure.";
 "feedback.error.validation" = "Vérifiez que votre adresse email est valide et que le message n'est pas vide.";
 "feedback.error.server" = "Le serveur n'a pas pu traiter le message. Veuillez réessayer plus tard.";
+
+"profile.menu.newInstance" = "Nouvelle instance…";
+"profile.newInstance.title" = "Ouvrir une nouvelle instance";
+"profile.newInstance.message" = "Choisissez un profil à lancer en tant qu'instance séparée. Chaque profil dispose de ses propres serveurs, préférences et paramètres, et fonctionne en parallèle de celui-ci.";
+"profile.newInstance.launch" = "Lancer";
+"profile.newInstance.createNew" = "Nouveau profil…";
+"profile.newInstance.picker.accessibilityLabel" = "Profil à lancer";
+"profile.newInstance.picker.currentSuffix" = "%@ (actuel)";
+"profile.newInstance.error.title" = "Impossible de lancer l'instance";
+"profile.newInstance.error.sameProfile" = "Le profil « %@ » est déjà ouvert dans cette fenêtre. Choisissez un autre profil ou créez-en un nouveau.";
+"profile.create.title" = "Créer un nouveau profil";
+"profile.create.message" = "Saisissez un nom pour le nouveau profil. Une instance distincte de ttaccessible se lancera avec ses propres paramètres et serveurs enregistrés.";
+"profile.create.launch" = "Créer et lancer";
+"profile.create.placeholder" = "Nom du profil";
+"profile.create.field.accessibilityLabel" = "Nom du profil";
+"profile.create.error.empty" = "Veuillez saisir un nom pour le profil.";
+"profile.create.error.invalid" = "Le nom du profil ne contient aucun caractère utilisable. Essayez un nom avec des lettres ou des chiffres.";
+"profile.create.error.reservedDefault" = "Le nom « Default » est réservé. Veuillez choisir un autre nom.";

--- a/App/ttaccessible/ttaccessibleApp.swift
+++ b/App/ttaccessible/ttaccessibleApp.swift
@@ -36,6 +36,10 @@ struct ttaccessibleApp: App {
                     appDelegate.openNewInstanceDialog()
                 }
                 .keyboardShortcut("n", modifiers: [.command, .shift])
+
+                Button(L10n.text("profile.menu.manage")) {
+                    appDelegate.openManageProfilesDialog()
+                }
             }
 
             CommandGroup(after: .help) {

--- a/App/ttaccessible/ttaccessibleApp.swift
+++ b/App/ttaccessible/ttaccessibleApp.swift
@@ -29,6 +29,13 @@ struct ttaccessibleApp: App {
                 Button(L10n.text("update.menu.checkForUpdates")) {
                     appDelegate.checkForUpdates()
                 }
+
+                Divider()
+
+                Button(L10n.text("profile.menu.newInstance")) {
+                    appDelegate.openNewInstanceDialog()
+                }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
             }
 
             CommandGroup(after: .help) {


### PR DESCRIPTION
## Summary

Adds TeamTalk-style profiles to ttaccessible so two instances of the app can run side by side, each with its own saved servers, preferences, passwords, sound packs, and chat history.

- New **New Instance…** item in the app menu (⌘⇧N) shows a picker of existing profiles plus a **New Profile…** button. Selecting a profile launches a separate process via `NSWorkspace.openApplication` with `-profile <slug>` and `createsNewApplicationInstance: true` — no in-app switching, both instances coexist.
- Each profile gets its own `UserDefaults(suiteName:)`, an Application Support subdirectory (`~/Library/Application Support/ttaccessible/profiles/<slug>/`), and a `kSecAttrService` namespace for the keychain.
- `ProfileContext` is resolved lazily from `CommandLine.arguments` on first access, so it's bound before any store is constructed. Stores that already accepted a `UserDefaults` injection now default to `ProfileContext.current.userDefaults`. Stores that hardcoded `.standard` / Application Support paths (`SoundPlayer`, `ChannelChatHistoryStore`, `AnnouncementService`, `FeedbackWindowController`) route through `ProfileContext` too.
- The **Default** profile keeps using `UserDefaults.standard` and the historical Application Support paths — no migration, existing installs see no change.
- Non-default profiles append their display name to the saved-servers and connected-server window titles so multiple running instances are visually distinguishable (e.g. `TeamTalk Servers — Work`).
- New strings localized in en + fr (vouvoiement).

## Architecture

Three new files:

- `Models/ProfileContext.swift` — identifies the active profile and exposes its `UserDefaults`, Application Support root, sound-packs directory, chat-history directory, keychain service name, and a `decorateWindowTitle(_:)` helper. The singleton `current` resolves once from `-profile <slug>` (or the `TTACCESSIBLE_PROFILE` env var) and registers unknown slugs on the fly so a freshly chosen profile works on its very first launch.
- `Services/ProfileRegistry.swift` — stores the list of profiles in a dedicated `UserDefaults(suiteName: "com.math65.ttaccessible.profiles")` shared across instances, so a profile created in one instance shows up in another's picker immediately.
- `AppKit/AppDelegate+NewInstance.swift` — the menu action: shows the picker, prompts for a new name when requested, calls `NSWorkspace.openApplication`. Refuses to launch a second instance of the same profile (which would mean two processes writing to the same suite).

## Test plan

- [x] Builds clean (`Release`, no warnings).
- [x] Manually tested: New Instance picker launches a second process; the second process has its own saved-servers list, preferences, and window title suffix.
- [ ] Default profile data carries over from a pre-PR install (no migration step required, just confirm).
- [ ] Verify keychain prompts on first server-password access in a new profile.
- [ ] Verify French strings render with `defaults write -g AppleLanguages -array fr en` then relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)