### PR TITLE
Add "No output device" option to audio preferences

### DIFF
--- a/App/ttaccessible/Models/AudioDevicePreference.swift
+++ b/App/ttaccessible/Models/AudioDevicePreference.swift
@@ -8,12 +8,24 @@
 import Foundation
 
 struct AudioDevicePreference: Codable, Equatable {
+    /// Sentinel `persistentID` that means "do not initialize an output device
+    /// at all" (rather than picking a real device or the system default).
+    /// Used by the Audio preferences pane's output picker so streaming
+    /// profiles can connect, transmit, and hear nothing — the main profile
+    /// carries the audio.
+    static let noOutputSentinelID = "__no_output__"
+
     var persistentID: String?
     var displayName: String?
 
     static let systemDefault = AudioDevicePreference(persistentID: nil, displayName: nil)
+    static let noOutput = AudioDevicePreference(persistentID: noOutputSentinelID, displayName: nil)
 
     nonisolated var usesSystemDefault: Bool {
         persistentID?.isEmpty != false
+    }
+
+    nonisolated var usesNoOutput: Bool {
+        persistentID == AudioDevicePreference.noOutputSentinelID
     }
 }

--- a/App/ttaccessible/Services/AppPreferencesStore.swift
+++ b/App/ttaccessible/Services/AppPreferencesStore.swift
@@ -668,6 +668,9 @@ final class AudioPreferencesStore: ObservableObject {
     }
 
     func selectionID(for preference: AudioDevicePreference, devices: [AudioDeviceOption]) -> String {
+        if preference.usesNoOutput {
+            return Self.noOutputDeviceTag
+        }
         guard let persistentID = preference.persistentID,
               devices.contains(where: { $0.persistentID == persistentID }) else {
             return Self.defaultDeviceTag
@@ -720,6 +723,9 @@ final class AudioPreferencesStore: ObservableObject {
     }
 
     private func preference(for selectionID: String, devices: [AudioDeviceOption]) -> AudioDevicePreference {
+        if selectionID == Self.noOutputDeviceTag {
+            return .noOutput
+        }
         guard selectionID != Self.defaultDeviceTag,
               let device = devices.first(where: { $0.id == selectionID }) else {
             return .systemDefault
@@ -728,6 +734,10 @@ final class AudioPreferencesStore: ObservableObject {
     }
 
     private static let defaultDeviceTag = "__system_default__"
+    // Mirrors AudioDevicePreference.noOutputSentinelID — duplicated to keep
+    // this `static let` usable from `private func preference(...)` without
+    // poking through to the model namespace at every call site.
+    fileprivate static let noOutputDeviceTag = AudioDevicePreference.noOutputSentinelID
 }
 
 @MainActor

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -123,7 +123,16 @@ extension TeamTalkConnectionController {
                 return
             }
 
-            if hadOutput, let instance = self.instance {
+            // Re-open output if either: (a) it was open before the restart, or
+            // (b) it wasn't open but the user's current preference is a real
+            // device. Case (b) covers the no-output→device switch while only
+            // the mic is active: hadOutput is false, but the user does want
+            // playback after the change. ensureDirectOutputAudioReadyLocked
+            // self-skips when the preference is no-output, so an unconditional
+            // call would also be safe — this guard just avoids the function
+            // call when there's clearly nothing to do.
+            let prefersOutputDevice = !self.preferencesStore.preferences.preferredOutputDevice.usesNoOutput
+            if (hadOutput || prefersOutputDevice), let instance = self.instance {
                 do {
                     try self.ensureDirectOutputAudioReadyLocked(instance: instance)
                     if self.masterMuted {
@@ -509,6 +518,14 @@ extension TeamTalkConnectionController {
 
     func ensureDirectOutputAudioReadyLocked(instance: UnsafeMutableRawPointer) throws {
         guard outputAudioReady == false else {
+            return
+        }
+
+        // Explicit "no output device" preference: the user wants this profile
+        // to transmit and stay connected while another instance carries the
+        // audio. Skip the SDK init entirely and leave outputAudioReady=false.
+        if preferencesStore.preferences.preferredOutputDevice.usesNoOutput {
+            AudioLogger.log("ensureDirectOutputAudioReady: preference is no-output — skipping init")
             return
         }
 

--- a/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct PreferencesAudioView: View {
     private let defaultDeviceTag = "__system_default__"
+    private let noOutputDeviceTag = AudioDevicePreference.noOutputSentinelID
 
     @ObservedObject var store: AudioPreferencesStore
 
@@ -22,6 +23,7 @@ struct PreferencesAudioView: View {
                     Text(L10n.text("preferences.audio.outputDevice"))
                     Picker("", selection: $selectedOutputID) {
                         Text(L10n.text("preferences.audio.systemDefault")).tag(defaultDeviceTag)
+                        Text(L10n.text("preferences.audio.noOutput")).tag(noOutputDeviceTag)
                         ForEach(store.state.catalog.outputDevices) { device in
                             Text(device.displayName).tag(device.persistentID)
                         }

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "preferences.audio.outputDevice" = "Output device";
 "preferences.audio.inputDevice" = "Input device";
 "preferences.audio.systemDefault" = "System default";
+"preferences.audio.noOutput" = "No output device";
 "preferences.audio.advanced.title" = "Microphone";
 "preferences.audio.advanced.summary.active" = "%@, %@.";
 "preferences.audio.advanced.summary.aecOn" = "echo cancellation enabled";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -380,6 +380,7 @@
 "preferences.audio.outputDevice" = "Périphérique de sortie";
 "preferences.audio.inputDevice" = "Périphérique d'entrée";
 "preferences.audio.systemDefault" = "Par défaut du système";
+"preferences.audio.noOutput" = "Aucune sortie audio";
 "preferences.audio.advanced.title" = "Microphone";
 "preferences.audio.advanced.summary.active" = "%@, %@.";
 "preferences.audio.advanced.summary.aecOn" = "annulation d'écho activée";


### PR DESCRIPTION
## Summary

Adds a third item to the Output device picker in the Audio preferences pane: **No output device**. Picking it makes the profile transmit and stay connected without ever opening a sound output device — useful for streaming profiles, server-monitor windows, or any setup where another logged-in profile is already carrying the audio.

## Behaviour

- Selecting **No output device** persists `AudioDevicePreference.noOutput` (sentinel `persistentID = "__no_output__"`).
- `ensureDirectOutputAudioReadyLocked` is the single entry point every code path uses to open the SDK output. It now early-returns (logs + leaves `outputAudioReady = false`) when the preference is no-output. Channel-join, reconnect, restart-sound-system, mic-start, and AEC paths all flow through this function, so they inherit the behaviour without further changes.
- `restartSoundSystem`'s output re-open guard is loosened: it used to gate on "was output open before the restart?", which would leave the device closed when switching FROM no-output TO a real device while the mic was active. New gate: "was open before, OR is the current preference a real device?" The short-circuit in `ensureDirectOutputAudioReadyLocked` keeps the unconditional case safe.

## What this is not

- Not a runtime mute — master mute already exists for that.
- Not a way to disable input. The input picker is unchanged; no-output applies to output only.
- Not Codable-breaking. Existing saved preferences with `persistentID == nil` still mean system default.

## Test plan

- [x] Builds clean in Release, no new warnings.
- [ ] Pick "No output device" while disconnected → connect to a server → channel join: no playback, mic transmits, you appear in the channel.
- [ ] Pick "No output device" while connected and in a channel → audio playback should stop without disconnecting.
- [ ] Switch from "No output device" back to a real device while in a channel with mic active → playback should resume after the SDK restart.
- [ ] Restart the app on a profile saved with no-output → connection works, no SDK output init attempt in the audio log (look for the `no-output preference — skipping init` line).
- [ ] French UI: picker shows "Aucune sortie audio".

🤖 Generated with [Claude Code](https://claude.com/claude-code)