### PR TITLE
Accessibility & VoiceOver: Preferences cleanup, VO-Space activation, and rename to tt-Accessible

### DIFF
--- a/App/ttaccessible-Info.plist
+++ b/App/ttaccessible-Info.plist
@@ -62,7 +62,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>tt-Accessible</string>
+	<key>CFBundleDisplayName</key>
+	<string>tt-Accessible</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
@@ -72,13 +74,13 @@
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>TTAccessible can optionally control VoiceOver to read incoming messages while the app is in the background.</string>
+	<string>tt-Accessible can optionally control VoiceOver to read incoming messages while the app is in the background.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>TTAccessible uses the microphone to talk in TeamTalk channels.</string>
+	<string>tt-Accessible uses the microphone to talk in TeamTalk channels.</string>
 	<key>NSAudioCaptureUsageDescription</key>
-	<string>TTAccessible can capture audio from other applications to stream it to TeamTalk channels.</string>
+	<string>tt-Accessible can capture audio from other applications to stream it to TeamTalk channels.</string>
 	<key>NSScreenCaptureUsageDescription</key>
-	<string>TTAccessible can capture audio from specific applications to stream it to TeamTalk channels.</string>
+	<string>tt-Accessible can capture audio from specific applications to stream it to TeamTalk channels.</string>
 	<key>SUFeedURL</key>
 	<string>https://math65.github.io/ttaccessible/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -1355,6 +1355,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func toggleHearMyself() {
         guard menuState.mode == .connectedServer else { return }
         connectionController.toggleHearMyself { [weak self] enabled in
+            self?.menuState.setHearMyselfEnabled(enabled)
             let key = enabled ? "shortcuts.hearMyself.announced.on" : "shortcuts.hearMyself.announced.off"
             self?.announceWithVoiceOver(L10n.text(key))
         }

--- a/App/ttaccessible/AppKit/ConnectedServerOutlineView.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerOutlineView.swift
@@ -29,6 +29,14 @@ final class ConnectedServerOutlineView: NSOutlineView {
         return actionDelegate?.connectedServerOutlineView(self, menuForRow: row)
     }
 
+    // VO-Espace sur l'arbre (sans interagir) effectue l'action par défaut sur la ligne
+    // sélectionnée, exactement comme la touche Entrée. Sans cela, VO-Espace n'agit que
+    // lorsqu'on a « interagi » avec l'arbre (curseur VoiceOver descendu sur une cellule).
+    override func accessibilityPerformPress() -> Bool {
+        actionDelegate?.connectedServerOutlineViewDidRequestDefaultAction(self)
+        return true
+    }
+
     override func keyDown(with event: NSEvent) {
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
            event.keyCode == 36 || event.keyCode == 76 {

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+ChannelActions.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+ChannelActions.swift
@@ -325,7 +325,10 @@ extension ConnectedServerViewController {
         guard let channel = selectedChannel else {
             return
         }
+        join(channel)
+    }
 
+    func join(_ channel: ConnectedServerChannel) {
         if channel.isCurrentChannel {
             announce(L10n.format("connectedServer.action.alreadyInChannel", displayText(for: .channel(channel))))
             return
@@ -421,17 +424,25 @@ extension ConnectedServerViewController {
     }
 
     func performDefaultAction() {
-        switch selectedNode {
+        guard let node = selectedNode else {
+            return
+        }
+        performDefaultAction(for: node)
+    }
+
+    // Action par défaut sur un nœud explicite (la ligne sous le curseur VoiceOver),
+    // sans dépendre de la sélection : sans interaction le tableau n'a aucune ligne
+    // sélectionnée, mais VO-Espace doit quand même agir sur la ligne pressée.
+    func performDefaultAction(for node: ServerTreeNode) {
+        switch node {
         case .channel(let channel):
             if channel.isCurrentChannel {
                 leaveCurrentChannel(nil)
             } else {
-                joinSelectedChannel(nil)
+                join(channel)
             }
-        case .user:
-            openPrivateConversation(nil)
-        case .none:
-            return
+        case .user(let user):
+            appDelegate.openPrivateConversation(userID: user.id, displayName: user.displayName)
         }
     }
 

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+OutlineDelegate.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+OutlineDelegate.swift
@@ -102,14 +102,21 @@ extension ConnectedServerViewController: NSOutlineViewDelegate {
         guard let node = item as? ServerTreeNode else { return nil }
 
         let identifier = NSUserInterfaceItemIdentifier("ConnectedServerCell")
-        let textField: NSTextField
+        let textField: PressActionTextField
 
-        if let cell = outlineView.makeView(withIdentifier: identifier, owner: self) as? NSTextField {
+        if let cell = outlineView.makeView(withIdentifier: identifier, owner: self) as? PressActionTextField {
             textField = cell
         } else {
-            textField = NSTextField(labelWithString: "")
+            textField = PressActionTextField(labelWithString: "")
             textField.identifier = identifier
             textField.lineBreakMode = .byTruncatingTail
+        }
+
+        // VO-Espace effectue l'action par défaut sur CE nœud (rejoindre/quitter un salon,
+        // ouvrir un message privé), comme la touche Entrée — indépendamment de la
+        // sélection, car sans interaction l'arbre n'a aucune ligne sélectionnée.
+        textField.onPress = { [weak self] in
+            self?.performDefaultAction(for: node)
         }
 
         let accessLabel = accessibilityText(for: node)

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+UserActions.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+UserActions.swift
@@ -129,17 +129,14 @@ extension ConnectedServerViewController {
         return slider
     }
 
-    private func makeVolumeValueLabel(value: Double) -> NSTextField {
-        let valueLabel = NSTextField(labelWithString: VolumeSliderHandler.formatPercent(value))
-        valueLabel.font = .monospacedDigitSystemFont(ofSize: NSFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)
-        valueLabel.alignment = .right
+    private func makeVolumeValueLabel(value: Double) -> PercentValueView {
+        let valueLabel = PercentValueView(text: VolumeSliderHandler.formatPercent(value))
         valueLabel.setContentHuggingPriority(.required, for: .horizontal)
-        valueLabel.setAccessibilityElement(false)
         valueLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
         return valueLabel
     }
 
-    private func makeVolumeSliderRow(title: String, slider: NSSlider, valueLabel: NSTextField) -> NSStackView {
+    private func makeVolumeSliderRow(title: String, slider: NSSlider, valueLabel: NSView) -> NSStackView {
         let titleLabel = NSTextField(labelWithString: title)
         titleLabel.setContentHuggingPriority(.required, for: .horizontal)
         titleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 86).isActive = true
@@ -445,6 +442,45 @@ extension ConnectedServerViewController {
     }
 }
 
+/// A label whose text stays on screen but is never exposed to VoiceOver. NSTextField
+/// derives `isAccessibilityElement` from its content, so `setAccessibilityElement(false)`
+/// doesn't reliably suppress it (notably inside an NSAlert, which reads accessory static
+/// text). Hard-overriding the getter does.
+/// Right-aligned percentage readout that DRAWS its text rather than using an NSTextField,
+/// so it stays visible for sighted users but offers VoiceOver no text to read. An NSAlert
+/// reads the value of descendant NSTextFields in its accessory even when they aren't
+/// accessibility elements; a plain drawing view sidesteps that entirely.
+private final class PercentValueView: NSView {
+    var text: String { didSet { needsDisplay = true; invalidateIntrinsicContentSize() } }
+
+    private static let font = NSFont.monospacedDigitSystemFont(
+        ofSize: NSFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)
+    private var attributes: [NSAttributedString.Key: Any] {
+        [.font: Self.font, .foregroundColor: NSColor.labelColor]
+    }
+
+    init(text: String) {
+        self.text = text
+        super.init(frame: .zero)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func isAccessibilityElement() -> Bool { false }
+
+    override var intrinsicContentSize: NSSize {
+        let size = (text as NSString).size(withAttributes: attributes)
+        return NSSize(width: max(44, ceil(size.width)), height: ceil(size.height))
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let str = text as NSString
+        let size = str.size(withAttributes: attributes)
+        str.draw(at: NSPoint(x: bounds.width - size.width,            // right-aligned
+                             y: (bounds.height - size.height) / 2),   // vertically centered
+                 withAttributes: attributes)
+    }
+}
+
 private class VolumeSliderHandler: NSObject {
     enum Stream {
         case voice
@@ -455,7 +491,7 @@ private class VolumeSliderHandler: NSObject {
     let userID: Int32
     let stream: Stream
     let connectionController: TeamTalkConnectionController
-    weak var valueLabel: NSTextField?
+    weak var valueLabel: PercentValueView?
 
     init(userID: Int32, stream: Stream, connectionController: TeamTalkConnectionController) {
         self.userID = userID
@@ -468,7 +504,7 @@ private class VolumeSliderHandler: NSObject {
         sender.doubleValue = percent
         let formatted = Self.formatPercent(percent)
         sender.setAccessibilityValueDescription(formatted)
-        valueLabel?.stringValue = formatted
+        valueLabel?.text = formatted
         let clamped = TeamTalkConnectionController.userVolumeFromPercent(percent)
         switch stream {
         case .voice:

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+UserActions.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+UserActions.swift
@@ -442,14 +442,12 @@ extension ConnectedServerViewController {
     }
 }
 
-/// A label whose text stays on screen but is never exposed to VoiceOver. NSTextField
-/// derives `isAccessibilityElement` from its content, so `setAccessibilityElement(false)`
-/// doesn't reliably suppress it (notably inside an NSAlert, which reads accessory static
-/// text). Hard-overriding the getter does.
 /// Right-aligned percentage readout that DRAWS its text rather than using an NSTextField,
-/// so it stays visible for sighted users but offers VoiceOver no text to read. An NSAlert
-/// reads the value of descendant NSTextFields in its accessory even when they aren't
-/// accessibility elements; a plain drawing view sidesteps that entirely.
+/// so it stays visible for sighted users but offers VoiceOver no text to read. NSTextField
+/// derives `isAccessibilityElement` from its content, so `setAccessibilityElement(false)`
+/// doesn't reliably suppress it inside an NSAlert (which reads its accessory's descendant
+/// NSTextFields even when they aren't accessibility elements). A plain drawing view that
+/// hard-overrides `isAccessibilityElement()` to `false` sidesteps that entirely.
 private final class PercentValueView: NSView {
     var text: String { didSet { needsDisplay = true; invalidateIntrinsicContentSize() } }
 

--- a/App/ttaccessible/AppKit/ConnectedServerViewController.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController.swift
@@ -15,6 +15,20 @@ final class ServerTreeRowView: NSTableRowView {
     override func accessibilityCustomActions() -> [NSAccessibilityCustomAction]? { nil }
 }
 
+// Cellule d'étiquette qui transmet l'action « presser » de VoiceOver (VO-Espace)
+// à une closure, pour que VO-Espace active une ligne comme le fait la touche Entrée.
+// Sans cela, VO-Espace ne fait rien sur ces étiquettes et seule Entrée permet de
+// rejoindre un serveur / un salon.
+final class PressActionTextField: NSTextField {
+    var onPress: (() -> Void)?
+
+    override func accessibilityPerformPress() -> Bool {
+        guard let onPress else { return super.accessibilityPerformPress() }
+        onPress()
+        return true
+    }
+}
+
 
 final class ConnectedServerViewController: NSViewController {
     enum Column {

--- a/App/ttaccessible/AppKit/PreferencesWindowController.swift
+++ b/App/ttaccessible/AppKit/PreferencesWindowController.swift
@@ -434,6 +434,14 @@ private final class PreferencesSidebarCellView: NSTableCellView {
         nil
     }
 
+    // The row exposes the pane title as its own accessibility label, so don't let
+    // VoiceOver descend into the icon + text field (which made it read e.g.
+    // "Recording, circle image, Recording"). Returning no children leaves just the
+    // single label.
+    override func accessibilityChildren() -> [Any]? {
+        []
+    }
+
     func configure(with pane: PreferencesWindowController.Pane) {
         paneImageView.image = NSImage(systemSymbolName: pane.iconName, accessibilityDescription: nil)
         paneTextField.stringValue = pane.title

--- a/App/ttaccessible/AppKit/PreferencesWindowController.swift
+++ b/App/ttaccessible/AppKit/PreferencesWindowController.swift
@@ -172,6 +172,13 @@ private final class PreferencesContainerViewController: NSViewController {
         selectPane(.general)
     }
 
+    // Escape closes the Preferences window. As the window's content view
+    // controller, this VC is in the responder chain, so an unhandled Escape
+    // (cancelOperation:) bubbles up to here.
+    override func cancelOperation(_ sender: Any?) {
+        view.window?.performClose(nil)
+    }
+
     func warmupExpensiveDependencies() {
         audioPreferencesStore.warmup()
         notificationsPreferencesStore.prepareIfNeeded()
@@ -398,9 +405,13 @@ private final class PreferencesSidebarCellView: NSTableCellView {
 
         paneImageView.translatesAutoresizingMaskIntoConstraints = false
         paneImageView.imageScaling = .scaleProportionallyDown
+        // The row already carries the pane title as its accessibility label, so the
+        // icon and the duplicate text field shouldn't be separate VoiceOver stops.
+        paneImageView.setAccessibilityElement(false)
 
         paneTextField.translatesAutoresizingMaskIntoConstraints = false
         paneTextField.font = .systemFont(ofSize: NSFont.systemFontSize)
+        paneTextField.setAccessibilityElement(false)
 
         addSubview(paneImageView)
         addSubview(paneTextField)

--- a/App/ttaccessible/AppKit/SavedServersTableView.swift
+++ b/App/ttaccessible/AppKit/SavedServersTableView.swift
@@ -28,6 +28,14 @@ final class SavedServersTableView: NSTableView {
         return actionDelegate?.savedServersTableView(self, menuForRow: row)
     }
 
+    // VO-Espace sur le tableau (sans interagir) rejoint la ligne sélectionnée,
+    // exactement comme la touche Entrée. Sans cela, VO-Espace n'agit que lorsqu'on
+    // a « interagi » avec le tableau (curseur VoiceOver descendu sur une cellule).
+    override func accessibilityPerformPress() -> Bool {
+        actionDelegate?.savedServersTableViewDidRequestConnect(self)
+        return true
+    }
+
     override func keyDown(with event: NSEvent) {
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
            event.keyCode == 36 || event.keyCode == 76 {

--- a/App/ttaccessible/AppKit/SavedServersViewController.swift
+++ b/App/ttaccessible/AppKit/SavedServersViewController.swift
@@ -338,7 +338,14 @@ final class SavedServersViewController: NSViewController {
     }
 
     func connectSelectedServer() {
-        guard let record = selectedRecord, isConnecting == false else {
+        guard let record = selectedRecord else {
+            return
+        }
+        connect(to: record)
+    }
+
+    func connect(to record: SavedServerRecord) {
+        guard isConnecting == false else {
             return
         }
 
@@ -947,17 +954,24 @@ extension SavedServersViewController: NSTableViewDelegate {
         }
 
         let identifier = NSUserInterfaceItemIdentifier("SavedServersCell-\(tableColumn.identifier.rawValue)")
-        let textField: NSTextField
+        let textField: PressActionTextField
 
-        if let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTextField {
+        if let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? PressActionTextField {
             textField = cell
         } else {
-            textField = NSTextField(labelWithString: value)
+            textField = PressActionTextField(labelWithString: value)
             textField.identifier = identifier
             textField.lineBreakMode = .byTruncatingTail
         }
 
         textField.stringValue = value
+        // VO-Espace rejoint le serveur de CETTE ligne (celle sous le curseur VoiceOver),
+        // indépendamment de la sélection du tableau — sans interaction, le tableau n'a
+        // aucune ligne sélectionnée.
+        textField.onPress = { [weak self] in
+            guard let self, self.records.indices.contains(row) else { return }
+            self.connect(to: self.records[row])
+        }
         return textField
     }
 }

--- a/App/ttaccessible/AppKit/SavedServersWindowController.swift
+++ b/App/ttaccessible/AppKit/SavedServersWindowController.swift
@@ -66,6 +66,7 @@ final class SavedServersWindowController: NSWindowController {
             menuState.$hasSelection.map { _ in () }.eraseToAnyPublisher(),
             menuState.$isMasterMuted.map { _ in () }.eraseToAnyPublisher(),
             menuState.$isRecordingActive.map { _ in () }.eraseToAnyPublisher(),
+            menuState.$isHearMyselfEnabled.map { _ in () }.eraseToAnyPublisher(),
             menuState.$isInChannel.map { _ in () }.eraseToAnyPublisher()
         )
         .receive(on: DispatchQueue.main)
@@ -124,6 +125,13 @@ final class SavedServersWindowController: NSWindowController {
                 )
                 item.isEnabled = menuState.mode == .connectedServer && (recording || menuState.isInChannel)
             case .ttHearMyself:
+                // Mirror the Mute/Recording pattern: VoiceOver reads the toolbar
+                // item's label, so swap it to include "selected" when hearing-myself
+                // is on (plain label when off). Stays an ordinary button.
+                let on = menuState.isHearMyselfEnabled
+                item.label = L10n.text(on ? "toolbar.hearMyself.selected" : "toolbar.hearMyself")
+                item.paletteLabel = item.label
+                item.image = NSImage(systemSymbolName: "ear", accessibilityDescription: item.label)
                 item.isEnabled = menuState.mode == .connectedServer && menuState.isInChannel
             case .ttPreferences:
                 item.isEnabled = true

--- a/App/ttaccessible/Models/AppPreferences.swift
+++ b/App/ttaccessible/Models/AppPreferences.swift
@@ -11,7 +11,7 @@ struct AppPreferences: Codable, Equatable {
     static func defaultNicknameFromAccount() -> String {
         let fullName = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
         let firstWord = fullName.components(separatedBy: .whitespacesAndNewlines).first ?? ""
-        return firstWord.isEmpty ? "TTAccessible" : firstWord
+        return firstWord.isEmpty ? "tt-Accessible" : firstWord
     }
 
     enum ChannelSortMode: String, Codable, CaseIterable {

--- a/App/ttaccessible/Models/ConnectedServerSession.swift
+++ b/App/ttaccessible/Models/ConnectedServerSession.swift
@@ -36,6 +36,11 @@ struct ConnectedServerUser: Equatable, Identifiable {
         if username.isEmpty {
             return nickname
         }
+        // When the nickname and username are effectively the same, show it once
+        // (otherwise VoiceOver reads e.g. "dom (dom)" — the same name twice).
+        if nickname.caseInsensitiveCompare(username) == .orderedSame {
+            return nickname
+        }
         return "\(nickname) (\(username))"
     }
 

--- a/App/ttaccessible/Services/SavedServersMenuState.swift
+++ b/App/ttaccessible/Services/SavedServersMenuState.swift
@@ -33,6 +33,7 @@ final class SavedServersMenuState: ObservableObject {
     @Published private(set) var isSelectedUserChannelOperator = false
     @Published private(set) var isMasterMuted = false
     @Published private(set) var isRecordingActive = false
+    @Published private(set) var isHearMyselfEnabled = false
     @Published private(set) var isMediaStreamingActive = false
     @Published private(set) var selectedUserSubscriptionStates: [UserSubscriptionOption: Bool] = [:]
 
@@ -66,6 +67,7 @@ final class SavedServersMenuState: ObservableObject {
         setSelectedUsersState(hasSelectedUsers: false, hasSingleSelectedUser: false, hasSingleSelectedOtherUser: false, isSelectedUserMuted: false, isSelectedUserMediaFileMuted: false, isSelectedUserChannelOperator: false, states: [:])
         setMasterMuted(false)
         setRecordingActive(false)
+        setHearMyselfEnabled(false)
         setMediaStreamingActive(false)
     }
 
@@ -91,6 +93,10 @@ final class SavedServersMenuState: ObservableObject {
 
     func setRecordingActive(_ value: Bool) {
         if isRecordingActive != value { isRecordingActive = value }
+    }
+
+    func setHearMyselfEnabled(_ value: Bool) {
+        if isHearMyselfEnabled != value { isHearMyselfEnabled = value }
     }
 
     func setMediaStreamingActive(_ value: Bool) {

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Identity.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Identity.swift
@@ -23,7 +23,7 @@ extension TeamTalkConnectionController {
 
             let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
             // An empty nickname falls back to the same resolution used at connection time
-            // (saved-server nickname → default preference → "TTAccessible") instead of being
+            // (saved-server nickname → default preference → "tt-Accessible") instead of being
             // rejected, so clearing the field returns to the default nickname.
             let resolved = trimmed.isEmpty ? self.effectiveNickname(for: record) : trimmed
 

--- a/App/ttaccessible/Services/TeamTalkConnectionController.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController.swift
@@ -72,7 +72,7 @@ final class TeamTalkConnectionController {
 
     let queueKey = DispatchSpecificKey<Void>()
     let queue = DispatchQueue(label: "com.math65.ttaccessible.teamtalk")
-    let clientName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "TTAccessible"
+    let clientName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "tt-Accessible"
     let preferencesStore: AppPreferencesStore
     let userVolumeStore = UserVolumeStore()
     let lastChannelStore = LastChannelStore()
@@ -335,7 +335,7 @@ final class TeamTalkConnectionController {
             return preferredNickname
         }
 
-        return "TTAccessible"
+        return "tt-Accessible"
     }
 
     func clientVersion(for user: User) -> String {

--- a/App/ttaccessible/SwiftUI/PreferencesAccessibilityView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAccessibilityView.swift
@@ -11,7 +11,7 @@ struct PreferencesAccessibilityView: View {
     @ObservedObject var store: AccessibilityPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.accessibility.title")) {
             VStack(alignment: .leading, spacing: 14) {
                 Toggle(
                     L10n.text("preferences.accessibility.channelAnnouncements"),

--- a/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
@@ -41,7 +41,7 @@ struct PreferencesAnnouncementsView: View {
     }
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.announcements.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 12) {
                     Text(L10n.text("preferences.notifications.backgroundAnnouncements.title"))

--- a/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
@@ -48,17 +48,19 @@ struct PreferencesAnnouncementsView: View {
                         .font(.headline)
                         .accessibilityAddTraits(.isHeader)
 
-                    Toggle(
-                        L10n.text("preferences.notifications.useGlobalMode"),
-                        isOn: Binding(
-                            get: { notificationsStore.state.useGlobalAnnouncementMode },
-                            set: { notificationsStore.updateUseGlobalAnnouncementMode($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { notificationsStore.state.useGlobalAnnouncementMode },
+                        set: { notificationsStore.updateUseGlobalAnnouncementMode($0) }
+                    )) {
+                        Text(L10n.text("preferences.notifications.useGlobalMode"))
+                            .accessibilityHidden(true)
+                    }
+                    .accessibilityLabel(L10n.text("preferences.notifications.useGlobalMode"))
 
                     if notificationsStore.state.useGlobalAnnouncementMode {
                         VStack(alignment: .leading, spacing: 6) {
                             Text(L10n.text("preferences.notifications.globalMode"))
+                                .accessibilityHidden(true)
                             Picker(
                                 L10n.text("preferences.notifications.globalMode"),
                                 selection: Binding(
@@ -77,6 +79,7 @@ struct PreferencesAnnouncementsView: View {
                         ForEach(BackgroundMessageAnnouncementType.allCases) { type in
                             VStack(alignment: .leading, spacing: 6) {
                                 Text(L10n.text(type.titleLocalizationKey))
+                                    .accessibilityHidden(true)
                                 Picker(
                                     L10n.text(type.titleLocalizationKey),
                                     selection: Binding(
@@ -180,32 +183,35 @@ struct PreferencesAnnouncementsView: View {
                         .font(.headline)
                         .accessibilityAddTraits(.isHeader)
 
-                    Toggle(
-                        L10n.text("preferences.accessibility.channelAnnouncements"),
-                        isOn: Binding(
-                            get: { accessibilityStore.state.channelMessagesEnabled },
-                            set: { accessibilityStore.updateVoiceOverChannelMessagesEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { accessibilityStore.state.channelMessagesEnabled },
+                        set: { accessibilityStore.updateVoiceOverChannelMessagesEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.accessibility.channelAnnouncements"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.accessibility.channelAnnouncements"))
 
-                    Toggle(
-                        L10n.text("preferences.accessibility.privateAnnouncements"),
-                        isOn: Binding(
-                            get: { accessibilityStore.state.privateMessagesEnabled },
-                            set: { accessibilityStore.updateVoiceOverPrivateMessagesEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { accessibilityStore.state.privateMessagesEnabled },
+                        set: { accessibilityStore.updateVoiceOverPrivateMessagesEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.accessibility.privateAnnouncements"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.accessibility.privateAnnouncements"))
 
-                    Toggle(
-                        L10n.text("preferences.accessibility.broadcastAnnouncements"),
-                        isOn: Binding(
-                            get: { accessibilityStore.state.broadcastMessagesEnabled },
-                            set: { accessibilityStore.updateVoiceOverBroadcastMessagesEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { accessibilityStore.state.broadcastMessagesEnabled },
+                        set: { accessibilityStore.updateVoiceOverBroadcastMessagesEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.accessibility.broadcastAnnouncements"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.accessibility.broadcastAnnouncements"))
 
                     DisclosureGroup(L10n.text("preferences.accessibility.historyAnnouncements")) {
                         HStack(spacing: 12) {
@@ -226,14 +232,15 @@ struct PreferencesAnnouncementsView: View {
                                 .padding(.top, 4)
 
                             ForEach(group.kinds, id: \.self) { kind in
-                                Toggle(
-                                    L10n.text(kind.localizationKey),
-                                    isOn: Binding(
-                                        get: { accessibilityStore.isSessionHistoryKindEnabled(kind) },
-                                        set: { accessibilityStore.updateSessionHistoryKindEnabled(kind, $0) }
-                                    )
-                                )
+                                Toggle(isOn: Binding(
+                                    get: { accessibilityStore.isSessionHistoryKindEnabled(kind) },
+                                    set: { accessibilityStore.updateSessionHistoryKindEnabled(kind, $0) }
+                                )) {
+                                    Text(L10n.text(kind.localizationKey))
+                                        .accessibilityHidden(true)
+                                }
                                 .toggleStyle(.switch)
+                                .accessibilityLabel(L10n.text(kind.localizationKey))
                             }
                         }
                     }

--- a/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
@@ -17,7 +17,7 @@ struct PreferencesAudioView: View {
     @State private var pushToTalkShortcutConfigured: Bool = KeyboardShortcuts.getShortcut(for: .pushToTalk) != nil
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.audio.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.outputDevice"))

--- a/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
@@ -21,6 +21,7 @@ struct PreferencesAudioView: View {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.outputDevice"))
+                        .accessibilityHidden(true)
                     Picker("", selection: $selectedOutputID) {
                         Text(L10n.text("preferences.audio.systemDefault")).tag(defaultDeviceTag)
                         Text(L10n.text("preferences.audio.noOutput")).tag(noOutputDeviceTag)
@@ -37,6 +38,7 @@ struct PreferencesAudioView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.inputDevice"))
+                        .accessibilityHidden(true)
                     Picker("", selection: $selectedInputID) {
                         Text(L10n.text("preferences.audio.systemDefault")).tag(defaultDeviceTag)
                         ForEach(store.state.catalog.inputDevices) { device in
@@ -61,14 +63,15 @@ struct PreferencesAudioView: View {
                         .font(.headline)
                         .accessibilityAddTraits(.isHeader)
 
-                    Toggle(
-                        L10n.text("preferences.audio.advanced.echoCancellation"),
-                        isOn: Binding(
-                            get: { store.advancedPreferences.echoCancellationEnabled },
-                            set: { store.updateEchoCancellationEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { store.advancedPreferences.echoCancellationEnabled },
+                        set: { store.updateEchoCancellationEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.audio.advanced.echoCancellation"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.audio.advanced.echoCancellation"))
 
                     Text(L10n.text("preferences.audio.advanced.echoCancellation.help"))
                         .font(.caption)
@@ -76,6 +79,7 @@ struct PreferencesAudioView: View {
 
                     VStack(alignment: .leading, spacing: 6) {
                         Text(L10n.text("preferences.audio.advanced.preset.label"))
+                            .accessibilityHidden(true)
                         Picker(
                             "",
                             selection: Binding(
@@ -160,6 +164,7 @@ struct PreferencesAudioView: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(L10n.text("preferences.audio.microphoneMode.label"))
+                    .accessibilityHidden(true)
                 Picker(
                     "",
                     selection: Binding(
@@ -180,6 +185,7 @@ struct PreferencesAudioView: View {
             if store.state.microphoneMode == .pushToTalk {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.pushToTalk.key.label"))
+                        .accessibilityHidden(true)
                     KeyboardShortcuts.Recorder(for: .pushToTalk)
                         .accessibilityLabel(L10n.text("preferences.audio.pushToTalk.key.label"))
                 }
@@ -191,14 +197,15 @@ struct PreferencesAudioView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Toggle(
-                    L10n.text("preferences.audio.pushToTalk.beep.label"),
-                    isOn: Binding(
-                        get: { store.state.pushToTalkBeepEnabled },
-                        set: { store.updatePushToTalkBeepEnabled($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.pushToTalkBeepEnabled },
+                    set: { store.updatePushToTalkBeepEnabled($0) }
+                )) {
+                    Text(L10n.text("preferences.audio.pushToTalk.beep.label"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.audio.pushToTalk.beep.label"))
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in

--- a/App/ttaccessible/SwiftUI/PreferencesBearWareView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesBearWareView.swift
@@ -20,7 +20,7 @@ struct PreferencesBearWareView: View {
     private let webLoginClient = BearWareWebLoginClient()
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.bearware.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Text(L10n.text("preferences.bearware.section"))
                     .font(.headline)

--- a/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
@@ -9,7 +9,7 @@ struct PreferencesConnectionView: View {
     @ObservedObject var store: ConnectionPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.connection.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.autoJoinRootChannel"),

--- a/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
@@ -11,59 +11,65 @@ struct PreferencesConnectionView: View {
     var body: some View {
         PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.connection.title")) {
             VStack(alignment: .leading, spacing: 18) {
-                Toggle(
-                    L10n.text("preferences.general.autoJoinRootChannel"),
-                    isOn: Binding(
-                        get: { store.state.autoJoinRootChannel },
-                        set: { store.updateAutoJoinRootChannel($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.autoJoinRootChannel },
+                    set: { store.updateAutoJoinRootChannel($0) }
+                )) {
+                    Text(L10n.text("preferences.general.autoJoinRootChannel"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.autoJoinRootChannel"))
 
-                Toggle(
-                    L10n.text("preferences.general.autoReconnect"),
-                    isOn: Binding(
-                        get: { store.state.autoReconnect },
-                        set: { store.updateAutoReconnect($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.autoReconnect },
+                    set: { store.updateAutoReconnect($0) }
+                )) {
+                    Text(L10n.text("preferences.general.autoReconnect"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.autoReconnect"))
 
-                Toggle(
-                    L10n.text("preferences.general.rejoinLastChannelOnReconnect"),
-                    isOn: Binding(
-                        get: { store.state.rejoinLastChannelOnReconnect },
-                        set: { store.updateRejoinLastChannelOnReconnect($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.rejoinLastChannelOnReconnect },
+                    set: { store.updateRejoinLastChannelOnReconnect($0) }
+                )) {
+                    Text(L10n.text("preferences.general.rejoinLastChannelOnReconnect"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.rejoinLastChannelOnReconnect"))
 
-                Toggle(
-                    L10n.text("preferences.general.connectToLastServerOnLaunch"),
-                    isOn: Binding(
-                        get: { store.state.connectToLastServerOnLaunch },
-                        set: { store.updateConnectToLastServerOnLaunch($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.connectToLastServerOnLaunch },
+                    set: { store.updateConnectToLastServerOnLaunch($0) }
+                )) {
+                    Text(L10n.text("preferences.general.connectToLastServerOnLaunch"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.connectToLastServerOnLaunch"))
 
-                Toggle(
-                    L10n.text("preferences.connection.skipKickConfirmation"),
-                    isOn: Binding(
-                        get: { store.state.skipKickConfirmation },
-                        set: { store.updateSkipKickConfirmation($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.skipKickConfirmation },
+                    set: { store.updateSkipKickConfirmation($0) }
+                )) {
+                    Text(L10n.text("preferences.connection.skipKickConfirmation"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.connection.skipKickConfirmation"))
 
-                Toggle(
-                    L10n.text("preferences.connection.adaptiveJitterBuffer"),
-                    isOn: Binding(
-                        get: { store.state.adaptiveJitterBuffer },
-                        set: { store.updateAdaptiveJitterBuffer($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.adaptiveJitterBuffer },
+                    set: { store.updateAdaptiveJitterBuffer($0) }
+                )) {
+                    Text(L10n.text("preferences.connection.adaptiveJitterBuffer"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.connection.adaptiveJitterBuffer"))
 
                 Picker(
                     L10n.text("preferences.connection.channelSortMode"),
@@ -87,14 +93,15 @@ struct PreferencesConnectionView: View {
                         .accessibilityAddTraits(.isHeader)
 
                     ForEach(UserSubscriptionOption.regularCases, id: \.self) { option in
-                        Toggle(
-                            L10n.text(option.preferencesKey),
-                            isOn: Binding(
-                                get: { store.isSubscriptionEnabledByDefault(option) },
-                                set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
-                            )
-                        )
+                        Toggle(isOn: Binding(
+                            get: { store.isSubscriptionEnabledByDefault(option) },
+                            set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
+                        )) {
+                            Text(L10n.text(option.preferencesKey))
+                                .accessibilityHidden(true)
+                        }
                         .toggleStyle(.switch)
+                        .accessibilityLabel(L10n.text(option.preferencesKey))
                     }
                 }
 
@@ -104,14 +111,15 @@ struct PreferencesConnectionView: View {
                         .accessibilityAddTraits(.isHeader)
 
                     ForEach(UserSubscriptionOption.interceptCases, id: \.self) { option in
-                        Toggle(
-                            L10n.text(option.preferencesKey),
-                            isOn: Binding(
-                                get: { store.isSubscriptionEnabledByDefault(option) },
-                                set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
-                            )
-                        )
+                        Toggle(isOn: Binding(
+                            get: { store.isSubscriptionEnabledByDefault(option) },
+                            set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
+                        )) {
+                            Text(L10n.text(option.preferencesKey))
+                                .accessibilityHidden(true)
+                        }
                         .toggleStyle(.switch)
+                        .accessibilityLabel(L10n.text(option.preferencesKey))
                     }
                 }
             }

--- a/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
@@ -16,7 +16,7 @@ struct PreferencesGeneralView: View {
     @State private var autoAwayCommitTask: Task<Void, Never>?
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.general.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.general.defaultNickname"))

--- a/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
@@ -20,6 +20,7 @@ struct PreferencesGeneralView: View {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.general.defaultNickname"))
+                        .accessibilityHidden(true)
                     TextField("", text: $nicknameDraft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(L10n.text("preferences.general.defaultNickname"))
@@ -35,6 +36,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.defaultStatusMessage"))
+                        .accessibilityHidden(true)
                     TextField("", text: $statusMessageDraft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(L10n.text("preferences.connection.defaultStatusMessage"))
@@ -46,6 +48,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.defaultGender"))
+                        .accessibilityHidden(true)
                     Picker(
                         L10n.text("preferences.connection.defaultGender"),
                         selection: Binding(
@@ -65,6 +68,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.autoAwayTimeout"))
+                        .accessibilityHidden(true)
                     HStack(alignment: .center, spacing: 8) {
                         TextField(
                             "",
@@ -89,6 +93,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.autoAwayStatusMessage"))
+                        .accessibilityHidden(true)
                     TextField("", text: $autoAwayStatusMessageDraft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(L10n.text("preferences.connection.autoAwayStatusMessage"))
@@ -100,23 +105,25 @@ struct PreferencesGeneralView: View {
 
                 Divider()
 
-                Toggle(
-                    L10n.text("preferences.general.relativeTimestamps"),
-                    isOn: Binding(
-                        get: { rootStore.preferences.useRelativeTimestamps },
-                        set: { rootStore.updateUseRelativeTimestamps($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { rootStore.preferences.useRelativeTimestamps },
+                    set: { rootStore.updateUseRelativeTimestamps($0) }
+                )) {
+                    Text(L10n.text("preferences.general.relativeTimestamps"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.relativeTimestamps"))
 
-                Toggle(
-                    L10n.text("preferences.general.autoDetectImport"),
-                    isOn: Binding(
-                        get: { rootStore.preferences.prefersAutomaticTeamTalkConfigDetection },
-                        set: { rootStore.updatePrefersAutomaticTeamTalkConfigDetection($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { rootStore.preferences.prefersAutomaticTeamTalkConfigDetection },
+                    set: { rootStore.updatePrefersAutomaticTeamTalkConfigDetection($0) }
+                )) {
+                    Text(L10n.text("preferences.general.autoDetectImport"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.autoDetectImport"))
 
                 Divider()
 
@@ -124,24 +131,26 @@ struct PreferencesGeneralView: View {
                     .font(.headline)
                     .accessibilityAddTraits(.isHeader)
 
-                Toggle(
-                    L10n.text("preferences.updates.autoCheck"),
-                    isOn: Binding(
-                        get: { rootStore.preferences.autoCheckForUpdates },
-                        set: { rootStore.updateAutoCheckForUpdates($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { rootStore.preferences.autoCheckForUpdates },
+                    set: { rootStore.updateAutoCheckForUpdates($0) }
+                )) {
+                    Text(L10n.text("preferences.updates.autoCheck"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.updates.autoCheck"))
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Toggle(
-                        L10n.text("preferences.updates.includeBeta"),
-                        isOn: Binding(
-                            get: { rootStore.preferences.includeBetaUpdates },
-                            set: { rootStore.updateIncludeBetaUpdates($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { rootStore.preferences.includeBetaUpdates },
+                        set: { rootStore.updateIncludeBetaUpdates($0) }
+                    )) {
+                        Text(L10n.text("preferences.updates.includeBeta"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.updates.includeBeta"))
 
                     Text(L10n.text("preferences.updates.includeBeta.help"))
                         .font(.caption)

--- a/App/ttaccessible/SwiftUI/PreferencesImportView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesImportView.swift
@@ -9,7 +9,7 @@ struct PreferencesImportView: View {
     @ObservedObject var store: AppPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.import.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.autoDetectImport"),

--- a/App/ttaccessible/SwiftUI/PreferencesNotificationsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesNotificationsView.swift
@@ -215,7 +215,7 @@ struct PreferencesNotificationsView: View {
     }
 
     var body: some View {
-        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.announcements.title")) {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.notifications.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.soundNotifications"),

--- a/App/ttaccessible/SwiftUI/PreferencesNotificationsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesNotificationsView.swift
@@ -215,7 +215,7 @@ struct PreferencesNotificationsView: View {
     }
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.announcements.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.soundNotifications"),

--- a/App/ttaccessible/SwiftUI/PreferencesPaneScrollView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesPaneScrollView.swift
@@ -6,6 +6,9 @@
 import SwiftUI
 
 struct PreferencesPaneScrollView<Content: View>: View {
+    // Names the scroll area for VoiceOver (it appends the "scroll area" role, so
+    // pass just the pane name, e.g. "General" → "General, scroll area").
+    let accessibilityLabel: String
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -17,5 +20,6 @@ struct PreferencesPaneScrollView<Content: View>: View {
             .padding(24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
@@ -78,14 +78,15 @@ struct PreferencesRecordingView: View {
 
                 Divider()
 
-                Toggle(
-                    L10n.text("preferences.recording.autoRestart"),
-                    isOn: Binding(
-                        get: { store.state.autoRestartRecording },
-                        set: { store.updateAutoRestartRecording($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.autoRestartRecording },
+                    set: { store.updateAutoRestartRecording($0) }
+                )) {
+                    Text(L10n.text("preferences.recording.autoRestart"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.recording.autoRestart"))
 
                 Text(L10n.text("preferences.recording.help"))
                     .font(.caption)

--- a/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
@@ -9,7 +9,7 @@ struct PreferencesRecordingView: View {
     @ObservedObject var store: RecordingPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.recording.title")) {
             VStack(alignment: .leading, spacing: 14) {
                 Text(L10n.text("preferences.recording.folder.label"))
                     .font(.headline)

--- a/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
@@ -15,13 +15,20 @@ struct PreferencesSoundsView: View {
         PreferencesPaneScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
-                    L10n.text("preferences.general.soundNotifications"),
                     isOn: Binding(
                         get: { store.state.soundNotificationsEnabled },
                         set: { store.updateSoundNotificationsEnabled($0) }
                     )
-                )
+                ) {
+                    // Visible label, but hidden from accessibility so macOS doesn't
+                    // expose it as a separate static-text stop next to the switch.
+                    // The switch keeps its native role; its name comes from
+                    // .accessibilityLabel below.
+                    Text(L10n.text("preferences.general.soundNotifications"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.soundNotifications"))
 
                 HStack(spacing: 12) {
                     Picker(
@@ -92,13 +99,19 @@ struct PreferencesSoundsView: View {
 
                     ForEach(NotificationSound.allCases, id: \.self) { sound in
                         Toggle(
-                            L10n.text(sound.localizationKey),
                             isOn: Binding(
                                 get: { store.isSoundEventEnabled(sound) },
                                 set: { store.setSoundEventEnabled(sound, enabled: $0) }
                             )
-                        )
+                        ) {
+                            // Visible label hidden from accessibility so it isn't a
+                            // separate static-text stop; the switch keeps its native
+                            // role and gets its name from .accessibilityLabel below.
+                            Text(L10n.text(sound.localizationKey))
+                                .accessibilityHidden(true)
+                        }
                         .toggleStyle(.switch)
+                        .accessibilityLabel(L10n.text(sound.localizationKey))
                     }
                 }
             }

--- a/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
@@ -12,7 +12,7 @@ struct PreferencesSoundsView: View {
     @State private var availablePacks = SoundPlayer.availablePacks
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.sounds.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     isOn: Binding(

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -950,6 +950,7 @@
 "toolbar.recording.stop" = "Stop recording";
 "toolbar.recording.stop.tooltip" = "Stop recording (⌘R)";
 "toolbar.hearMyself" = "Hear myself";
+"toolbar.hearMyself.selected" = "Hear myself, selected";
 "toolbar.hearMyself.tooltip" = "Toggle hearing yourself (⌘⇧H)";
 "preferences.updates.section" = "Updates";
 "preferences.updates.autoCheck" = "Check for updates automatically";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -210,8 +210,8 @@
 "connectedServer.volume.sliderLabel" = "Volume percentage";
 "connectedServer.volume.voice" = "Voice";
 "connectedServer.volume.mediaFile" = "Media file";
-"connectedServer.volume.voiceSliderLabel" = "Voice volume percentage";
-"connectedServer.volume.mediaFileSliderLabel" = "Media file volume percentage";
+"connectedServer.volume.voiceSliderLabel" = "Voice volume";
+"connectedServer.volume.mediaFileSliderLabel" = "Media file volume";
 "connectedServer.menu.makeOperator" = "Make channel operator";
 "connectedServer.menu.revokeOperator" = "Revoke channel operator";
 "user.menu.makeOperator" = "Make channel operator";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -350,7 +350,7 @@
 "preferences.notifications.tts.volume" = "Volume";
 "preferences.notifications.tts.volume.value" = "%@%%";
 "preferences.notifications.tts.test" = "Test voice";
-"preferences.notifications.tts.testPhrase" = "This is a TTAccessible speech test.";
+"preferences.notifications.tts.testPhrase" = "This is a tt-Accessible speech test.";
 "preferences.import.title" = "Import";
 "preferences.general.defaultNickname" = "Default nickname";
 "preferences.general.defaultNickname.help" = "Used when a saved server has no specific nickname.";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -350,7 +350,7 @@
 "preferences.notifications.tts.volume" = "Volume";
 "preferences.notifications.tts.volume.value" = "%@%%";
 "preferences.notifications.tts.test" = "Tester la voix";
-"preferences.notifications.tts.testPhrase" = "Ceci est un test de la synthèse vocale de TTAccessible.";
+"preferences.notifications.tts.testPhrase" = "Ceci est un test de la synthèse vocale de tt-Accessible.";
 "preferences.import.title" = "Import";
 "preferences.general.defaultNickname" = "Pseudo par défaut";
 "preferences.general.defaultNickname.help" = "Utilisé quand un serveur enregistré n'a pas de pseudo spécifique.";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -210,8 +210,8 @@
 "connectedServer.volume.sliderLabel" = "Volume en pourcentage";
 "connectedServer.volume.voice" = "Voix";
 "connectedServer.volume.mediaFile" = "Fichier média";
-"connectedServer.volume.voiceSliderLabel" = "Volume de la voix en pourcentage";
-"connectedServer.volume.mediaFileSliderLabel" = "Volume du fichier média en pourcentage";
+"connectedServer.volume.voiceSliderLabel" = "Volume de la voix";
+"connectedServer.volume.mediaFileSliderLabel" = "Volume du fichier média";
 "connectedServer.menu.makeOperator" = "Promouvoir opérateur de canal";
 "connectedServer.menu.revokeOperator" = "Révoquer opérateur de canal";
 "user.menu.makeOperator" = "Promouvoir opérateur de canal";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -950,6 +950,7 @@
 "toolbar.recording.stop" = "Arrêter l'enregistrement";
 "toolbar.recording.stop.tooltip" = "Arrêter l'enregistrement (⌘R)";
 "toolbar.hearMyself" = "M'entendre";
+"toolbar.hearMyself.selected" = "M'entendre, sélectionné";
 "toolbar.hearMyself.tooltip" = "Activer / désactiver l'écoute de soi (⌘⇧H)";
 "preferences.updates.section" = "Mises à jour";
 "preferences.updates.autoCheck" = "Vérifier les mises à jour automatiquement";

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# TTAccessible
+# tt-Accessible
 
 A native, fully accessible TeamTalk client for macOS, built with VoiceOver as a first-class citizen.
 
-The official TeamTalk Qt client on Mac has significant accessibility issues — broken navigation, unresponsive context menus, audio crackling, and sluggish VoiceOver announcements. TTAccessible is a from-scratch alternative that puts screen reader users first.
+The official TeamTalk Qt client on Mac has significant accessibility issues — broken navigation, unresponsive context menus, audio crackling, and sluggish VoiceOver announcements. tt-Accessible is a from-scratch alternative that puts screen reader users first.
 
 ## Features
 
@@ -87,7 +87,7 @@ The app is signed with a Developer ID certificate and notarized by Apple, so no 
 
 If you already use TeamTalk on your Mac, you can import your saved servers:
 
-1. Open TTAccessible
+1. Open tt-Accessible
 2. Go to **Server > Import TeamTalk Servers…**
 3. Select your `TeamTalk5.ini` file (the app navigates to the right folder automatically)
 


### PR DESCRIPTION
Hi Mathieu — this is the first of the smaller, themed PRs we discussed splitting out of #20: the low-risk, high-value accessibility group, rebased on current `main` (v1.7.0-beta.5). No audio or architecture changes here — those come in a later PR.

## Included

- **Preferences VoiceOver cleanup** — de-dupe the sidebar, Escape closes the window, label each scroll area, remove redundant static text, and collapse the sound-event switch labels into one element.
- **"Hear myself" toolbar button** reflects its on-state as VoiceOver-selected.
- **VO-Space (VoiceOver press) joins servers and channels** — previously only Return worked, and only while interacting with the table. Now the accessibility press action on the table/outline and its cells triggers the same connect / join.
- **Volume dialog** — stop VoiceOver reading the redundant "%" readout next to each slider (kept visible for sighted users; the slider already announces the value).
- **Collapse display name** when nickname == username (no double readout).
- **App rename to "tt-Accessible"** — note the hyphen, not "ttAccessible" as I first suggested. Eloquence and some other synthesizers mis-read the camelCase as a single run; a hyphen reads correctly across voices. `CFBundleName` / `CFBundleDisplayName` + user-facing copy only — the bundle identifier (`com.math65.ttaccessible`) and on-disk product name are unchanged.
- **BearWare pane fix** — `PreferencesBearWareView` now passes the scroll-area accessibility label that the labeled-scroll-area change makes required (the pane was added upstream after that change, so it was missing it).

Built against current `main`. Happy to adjust, squash further, or split.
