### PR TITLE
Audio: output-bypass engine, channel mixer, faster connect (device-switch deadlock cure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,13 @@ DerivedData/
 *.mode2v3
 *.perspectivev3
 xcuserdata/
+# Auto-generated shared scheme (not tracked upstream)
+App/ttaccessible.xcodeproj/xcshareddata/xcschemes/
 
 # Build artifacts
 BuildArtifacts/
+build_verify/
+*.slow-v5.22a-backup
 
 # macOS
 .DS_Store

--- a/App/ttaccessible-Info.plist
+++ b/App/ttaccessible-Info.plist
@@ -62,7 +62,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>tt-Accessible</string>
+	<key>CFBundleDisplayName</key>
+	<string>tt-Accessible</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
@@ -72,13 +74,13 @@
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>TTAccessible can optionally control VoiceOver to read incoming messages while the app is in the background.</string>
+	<string>tt-Accessible can optionally control VoiceOver to read incoming messages while the app is in the background.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>TTAccessible uses the microphone to talk in TeamTalk channels.</string>
+	<string>tt-Accessible uses the microphone to talk in TeamTalk channels.</string>
 	<key>NSAudioCaptureUsageDescription</key>
-	<string>TTAccessible can capture audio from other applications to stream it to TeamTalk channels.</string>
+	<string>tt-Accessible can capture audio from other applications to stream it to TeamTalk channels.</string>
 	<key>NSScreenCaptureUsageDescription</key>
-	<string>TTAccessible can capture audio from specific applications to stream it to TeamTalk channels.</string>
+	<string>tt-Accessible can capture audio from specific applications to stream it to TeamTalk channels.</string>
 	<key>SUFeedURL</key>
 	<string>https://math65.github.io/ttaccessible/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -143,6 +143,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.preloadPreferencesWindow()
         }
         hasFinishedLaunching = true
+        // Create the first TeamTalk instance in the background now. TT_InitTeamTalkPoll
+        // enumerates all CoreAudio devices (~12 s on a large rig); prewarming it here
+        // keeps that cost off the connect path so connecting is fast.
+        connectionController.prewarmConnection()
         handleLaunchTTFilesIfNeeded()
         processPendingTTFileURLsIfPossible()
         syncSparkleAutoCheckPreference()
@@ -1514,6 +1518,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         feedbackWindowController?.show()
     }
+
 
     // MARK: - Updates
 

--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -1355,6 +1355,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func toggleHearMyself() {
         guard menuState.mode == .connectedServer else { return }
         connectionController.toggleHearMyself { [weak self] enabled in
+            self?.menuState.setHearMyselfEnabled(enabled)
             let key = enabled ? "shortcuts.hearMyself.announced.on" : "shortcuts.hearMyself.announced.off"
             self?.announceWithVoiceOver(L10n.text(key))
         }

--- a/App/ttaccessible/AppKit/AudioGainControlView.swift
+++ b/App/ttaccessible/AppKit/AudioGainControlView.swift
@@ -112,6 +112,12 @@ final class AudioGainControlView: NSView {
         return true
     }
 
+    override func accessibilityPerformPress() -> Bool {
+        // VoiceOver double-tap resets the gain to unity (0 dB = 50% on the slider),
+        // matching the channel mixer's reset-on-press.
+        resetToZeroAccessibilityAction()
+    }
+
     override func accessibilityChildren() -> [Any]? {
         []
     }
@@ -137,6 +143,12 @@ final class AudioGainControlView: NSView {
     func adjust(by delta: Double) {
         let updated = min(max((slider.doubleValue + delta).rounded(), 0), 100)
         setAndNotify(Self.gainDB(forPercent: updated))
+    }
+
+    /// Nudge one step and return the spoken value (used by the mixer's Cmd+Up/Down).
+    func adjustAndDescribe(up: Bool) -> String {
+        adjust(by: up ? 1 : -1)
+        return Self.format(percent: slider.doubleValue)
     }
 
     func setAndNotify(_ value: Double) {

--- a/App/ttaccessible/AppKit/ChannelMixerCoordinator.swift
+++ b/App/ttaccessible/AppKit/ChannelMixerCoordinator.swift
@@ -1,0 +1,351 @@
+//
+//  ChannelMixerCoordinator.swift
+//  ttaccessible
+//
+//  Binds the ported virtual-accessibility engine (MixerVirtualAccessibility.swift) to
+//  ttAccessible's per-user audio. Builds one MixerStripDescriptor per other user in the
+//  current channel — voice volume %, media volume %, pan, mute — with live read/write
+//  closures through TeamTalkConnectionController. The A11yVirtualGridOverlayView it owns
+//  is embedded as a section in the main window; VoiceOver navigates Mixer → strip →
+//  controls and adjusts via swipe (the engine's increment/decrement). Keyboard shortcuts
+//  are added by ChannelMixerKeyboardController.
+//
+
+#if os(macOS)
+import AppKit
+import Combine
+
+/// One user's row for the VISIBLE (sighted) mixer rendering. VoiceOver uses the separate
+/// virtual-accessibility overlay, not this.
+struct MixerDisplayStrip: Identifiable, Equatable {
+    let id: Int32
+    let name: String
+    var voicePercent: Double
+    var mediaPercent: Double
+    var pan: Double
+    var muted: Bool
+    var soloed: Bool
+}
+
+@MainActor
+final class ChannelMixerCoordinator: ObservableObject {
+    /// Published snapshot driving the on-screen SwiftUI strips (accessibilityHidden on mac).
+    @Published private(set) var displayStrips: [MixerDisplayStrip] = []
+    let overlay = A11yVirtualGridOverlayView(frame: .zero)
+    private weak var controller: TeamTalkConnectionController?
+    private var session: ConnectedServerSession?
+
+    // Caches so the slider value the user sees is the EXACT value they set — the
+    // percent→SDK-volume→percent round-trip is lossy and would otherwise make the
+    // slider snap/jump while adjusting. muteCache is optimistic mute intent awaiting
+    // session confirmation (so the toggle is responsive and announces once).
+    private var voicePctCache: [Int32: Double] = [:]
+    private var mediaPctCache: [Int32: Double] = [:]
+    private var panCache: [Int32: Double] = [:]
+    private var muteCache: [Int32: Bool] = [:]
+    // Solo: while any user is soloed, every NON-soloed user is muted in OUR engine
+    // (independent of their persistent SDK mute). Lets you isolate one or more people.
+    private var soloed: Set<Int32> = []
+    private var lastKnownIDs: [Int32] = []
+    private var soloWasActive = false
+
+    // Adjustment steps (VO swipe + keyboard arrows share these).
+    private let volumeStep: Double = 2     // percent
+    private let panStep: Double = 0.05     // -1...+1
+
+    init(controller: TeamTalkConnectionController) {
+        self.controller = controller
+        overlay.configure(areaLabel: L10n.text("mixer.area.label"),
+                          areaRoleDescription: L10n.text("mixer.area.roleDescription")) { [weak self] in
+            self?.buildDescriptors() ?? []
+        }
+    }
+
+    func update(session: ConnectedServerSession) {
+        self.session = session
+        // Reconcile optimistic mute intent: once the session agrees, drop the override.
+        let ids = Set(usersInChannel().map { $0.id })
+        for (id, intent) in muteCache where !ids.contains(id) || isMutedFromSession(id) == intent {
+            muteCache[id] = nil
+        }
+        // Prune value caches for users no longer present.
+        voicePctCache = voicePctCache.filter { ids.contains($0.key) }
+        mediaPctCache = mediaPctCache.filter { ids.contains($0.key) }
+        panCache = panCache.filter { ids.contains($0.key) }
+        // Solo: drop leavers; re-apply engine mutes when the roster changed while solo is
+        // (or was just) active, so a joiner gets muted and a departed soloist clears.
+        soloed = soloed.intersection(ids)
+        let idList = Array(ids)
+        let nowActive = !soloed.isEmpty
+        if Set(lastKnownIDs) != ids && (nowActive || soloWasActive) {
+            reapplySolo()
+        }
+        soloWasActive = nowActive
+        lastKnownIDs = idList
+        overlay.rebuildStrips()
+        refreshDisplay()
+    }
+
+    /// The current user IDs the mixer shows (for the keyboard controller's routing).
+    func currentUserIDs() -> [Int32] { buildDescriptors().map { $0.id } }
+
+    // MARK: Descriptor building
+
+    private func usersInChannel() -> [ConnectedServerUser] {
+        guard let session else { return [] }
+        let myID = session.currentUser?.id
+        return (session.findChannelByID(session.currentChannelID)?.users ?? [])
+            .filter { $0.id != myID && $0.id > 0 }
+    }
+
+    func user(for id: Int32) -> ConnectedServerUser? {
+        usersInChannel().first { $0.id == id }
+    }
+
+    private func buildDescriptors() -> [MixerStripDescriptor] {
+        usersInChannel().map { descriptor(for: $0) }
+    }
+
+    private func descriptor(for user: ConnectedServerUser) -> MixerStripDescriptor {
+        let id = user.id
+        return MixerStripDescriptor(
+            id: id,
+            label: { [weak self] in self?.stripLabel(for: id) },
+            controls: [
+                .slider(voiceConfig(id: id)),
+                .slider(mediaConfig(id: id)),
+                .slider(panConfig(id: id)),
+                .toggle(muteConfig(id: id)),
+                .toggle(soloConfig(id: id))
+            ]
+        )
+    }
+
+    private func stripLabel(for id: Int32) -> String? {
+        guard let user = user(for: id) else { return nil }
+        var parts = [user.displayName]
+        parts.append(L10n.format("mixer.value.percent", Int(voicePercent(id).rounded())))
+        // Use the mixer's own mute state (optimistic intent + voice/media), the same
+        // state the mute toggle reports — so the strip name reflects a mute applied
+        // here immediately, instead of only the SDK's voice-mute flag.
+        if isMuted(id) { parts.append(L10n.text("mixer.toggle.muted")) }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: Live value access
+
+    private func voicePercent(_ id: Int32) -> Double {
+        if let cached = voicePctCache[id] { return cached }
+        guard let controller, let user = user(for: id) else { return 0 }
+        let v = controller.userVolumeStore.volume(forUsername: user.username) ?? user.volumeVoice
+        return Double(TeamTalkConnectionController.percentFromUserVolume(v))
+    }
+
+    private func mediaPercent(_ id: Int32) -> Double {
+        if let cached = mediaPctCache[id] { return cached }
+        guard let controller, let user = user(for: id) else { return 0 }
+        let v = controller.userVolumeStore.mediaFileVolume(forUsername: user.username) ?? user.volumeMediaFile
+        return Double(TeamTalkConnectionController.percentFromUserVolume(v))
+    }
+
+    private func panValue(_ id: Int32) -> Double {
+        if let cached = panCache[id] { return cached }
+        guard let controller, let user = user(for: id) else { return 0 }
+        return Double(controller.userVolumeStore.pan(forUsername: user.username) ?? 0)
+    }
+
+    private func isMutedFromSession(_ id: Int32) -> Bool {
+        guard let user = user(for: id) else { return false }
+        return user.isMuted || user.isMediaFileMuted
+    }
+
+    // MARK: Control configs
+
+    private func voiceConfig(id: Int32) -> VirtualSliderConfig {
+        VirtualSliderConfig(
+            label: L10n.text("mixer.voice.label.short"),
+            getValue: { [weak self] in self.map { Double(($0.voicePercent(id)).rounded()) } },
+            getDisplayString: { v in L10n.format("mixer.value.percent", Int(v.rounded())) },
+            setValue: { [weak self] v in self?.setVoice(id: id, percent: v) },
+            incrementValue: { [volumeStep] v in min(100, v + volumeStep) },
+            decrementValue: { [volumeStep] v in max(0, v - volumeStep) },
+            minValue: 0, maxValue: 100, resetValue: 50
+        )
+    }
+
+    private func mediaConfig(id: Int32) -> VirtualSliderConfig {
+        VirtualSliderConfig(
+            label: L10n.text("mixer.media.label.short"),
+            getValue: { [weak self] in self.map { Double(($0.mediaPercent(id)).rounded()) } },
+            getDisplayString: { v in L10n.format("mixer.value.percent", Int(v.rounded())) },
+            setValue: { [weak self] v in self?.setMedia(id: id, percent: v) },
+            incrementValue: { [volumeStep] v in min(100, v + volumeStep) },
+            decrementValue: { [volumeStep] v in max(0, v - volumeStep) },
+            minValue: 0, maxValue: 100, resetValue: 50
+        )
+    }
+
+    private func panConfig(id: Int32) -> VirtualSliderConfig {
+        VirtualSliderConfig(
+            label: L10n.text("mixer.pan.label.short"),
+            getValue: { [weak self] in self.map { $0.panValue(id) } },
+            getDisplayString: { v in ChannelMixerCoordinator.panDescription(v) },
+            setValue: { [weak self] v in self?.setPan(id: id, value: v) },
+            incrementValue: { [panStep] v in min(1, v + panStep) },
+            decrementValue: { [panStep] v in max(-1, v - panStep) },
+            minValue: -1, maxValue: 1, resetValue: 0
+        )
+    }
+
+    private func muteConfig(id: Int32) -> VirtualToggleConfig {
+        VirtualToggleConfig(
+            getLabel: { [weak self] in
+                // Action-style label so VoiceOver conveys state: "Unmute" means it's
+                // currently muted, "Mute" means it's not.
+                (self?.isMuted(id) ?? false) ? L10n.text("mixer.mute.action.unmute")
+                                             : L10n.text("mixer.mute.action.mute")
+            },
+            getState: { [weak self] in
+                guard let self else { return nil }
+                return self.muteCache[id] ?? self.isMutedFromSession(id)
+            },
+            setState: { [weak self] muted in self?.applyMute(id: id, muted: muted) },
+            onAnnouncement: L10n.text("mixer.toggle.muted"),
+            offAnnouncement: L10n.text("mixer.toggle.unmuted")
+        )
+    }
+
+    /// Mute the WHOLE user — both voice and media — since a single "Mute" should
+    /// silence everyone, including media-only sources like the radio bot.
+    func applyMute(id: Int32, muted: Bool) {
+        guard let controller else { return }
+        muteCache[id] = muted
+        controller.muteUser(userID: id, mute: muted)
+        controller.muteUserMediaFile(userID: id, mute: muted)
+        refreshDisplay()
+    }
+
+    private func soloConfig(id: Int32) -> VirtualToggleConfig {
+        VirtualToggleConfig(
+            getLabel: { [weak self] in
+                (self?.isSoloed(id) ?? false) ? L10n.text("mixer.solo.action.unsolo")
+                                              : L10n.text("mixer.solo.action.solo")
+            },
+            getState: { [weak self] in self?.isSoloed(id) },
+            setState: { [weak self] _ in self?.toggleSolo(id) },
+            onAnnouncement: L10n.text("mixer.solo.on"),
+            offAnnouncement: L10n.text("mixer.solo.off")
+        )
+    }
+
+    // MARK: Apply (also used by the keyboard controller)
+
+    func setVoice(id: Int32, percent: Double) {
+        guard let controller, let user = user(for: id) else { return }
+        let clamped = min(100, max(0, percent))
+        voicePctCache[id] = clamped
+        controller.setUserVoiceVolume(userID: id, username: user.username,
+                                      volume: TeamTalkConnectionController.userVolumeFromPercent(clamped))
+        refreshDisplay()
+    }
+
+    func setMedia(id: Int32, percent: Double) {
+        guard let controller, let user = user(for: id) else { return }
+        let clamped = min(100, max(0, percent))
+        mediaPctCache[id] = clamped
+        controller.setUserMediaFileVolume(userID: id, username: user.username,
+                                          volume: TeamTalkConnectionController.userVolumeFromPercent(clamped))
+        refreshDisplay()
+    }
+
+    func setPan(id: Int32, value: Double) {
+        guard let controller, let user = user(for: id) else { return }
+        let clamped = Double(min(1, max(-1, value)))
+        panCache[id] = clamped
+        controller.setUserPan(userID: id, username: user.username, pan: Float(clamped), engineMuted: soloMuted(id))
+        refreshDisplay()
+    }
+
+    // MARK: Solo
+
+    /// A user is solo-muted when solo is active and they are NOT one of the soloed users.
+    private func soloMuted(_ id: Int32) -> Bool { !soloed.isEmpty && !soloed.contains(id) }
+
+    func isSoloed(_ id: Int32) -> Bool { soloed.contains(id) }
+
+    func toggleSolo(_ id: Int32) {
+        if soloed.contains(id) { soloed.remove(id) } else { soloed.insert(id) }
+        soloWasActive = !soloed.isEmpty
+        reapplySolo()
+        refreshDisplay()
+    }
+
+    /// Push each user's combined engine settings (pan + solo-mute) — the solo set changed.
+    private func reapplySolo() {
+        guard let controller else { return }
+        for u in usersInChannel() {
+            controller.setUserPan(userID: u.id, username: u.username,
+                                  pan: Float(currentPan(u.id)), engineMuted: soloMuted(u.id))
+        }
+    }
+
+    /// Rebuild the published snapshot for the on-screen strips from current state.
+    func refreshDisplay() {
+        displayStrips = usersInChannel().map { u in
+            MixerDisplayStrip(id: u.id, name: u.displayName,
+                              voicePercent: currentVoicePercent(u.id),
+                              mediaPercent: currentMediaPercent(u.id),
+                              pan: currentPan(u.id),
+                              muted: isMuted(u.id),
+                              soloed: isSoloed(u.id))
+        }
+    }
+
+    func currentVoicePercent(_ id: Int32) -> Double { voicePercent(id) }
+    func currentMediaPercent(_ id: Int32) -> Double { mediaPercent(id) }
+    func currentPan(_ id: Int32) -> Double { panValue(id) }
+    func isMuted(_ id: Int32) -> Bool { muteCache[id] ?? isMutedFromSession(id) }
+    func toggleMute(_ id: Int32) { applyMute(id: id, muted: !isMuted(id)) }
+
+    // MARK: Keyboard actions (return the VoiceOver announcement string)
+
+    func nudgeVoice(_ id: Int32, up: Bool) -> String {
+        let v = min(100, max(0, currentVoicePercent(id) + (up ? volumeStep : -volumeStep)))
+        setVoice(id: id, percent: v)
+        return L10n.format("mixer.value.percent", Int(v.rounded()))
+    }
+    func nudgeMedia(_ id: Int32, up: Bool) -> String {
+        let v = min(100, max(0, currentMediaPercent(id) + (up ? volumeStep : -volumeStep)))
+        setMedia(id: id, percent: v)
+        // Qualified so VoiceOver distinguishes it from the plain-arrow voice nudge.
+        return L10n.format("mixer.media.label", L10n.format("mixer.value.percent", Int(v.rounded())))
+    }
+    func nudgePan(_ id: Int32, right: Bool) -> String {
+        let p = min(1, max(-1, currentPan(id) + (right ? panStep : -panStep)))
+        setPan(id: id, value: p)
+        return Self.panDescription(p)
+    }
+    func announceVoice(_ id: Int32) -> String { L10n.format("mixer.value.percent", Int(currentVoicePercent(id).rounded())) }
+    func announcePan(_ id: Int32) -> String { Self.panDescription(currentPan(id)) }
+    func resetVoice(_ id: Int32) -> String { setVoice(id: id, percent: 50); return L10n.format("mixer.value.percent", 50) }
+    func resetPan(_ id: Int32) -> String { setPan(id: id, value: 0); return Self.panDescription(0) }
+    func muteState(_ id: Int32) -> String {
+        isMuted(id) ? L10n.text("mixer.toggle.muted") : L10n.text("mixer.toggle.unmuted")
+    }
+    func toggleMuteAndAnnounce(_ id: Int32) -> String {
+        toggleMute(id)
+        return isMuted(id) ? L10n.text("mixer.toggle.muted") : L10n.text("mixer.toggle.unmuted")
+    }
+    func soloState(_ id: Int32) -> String { isSoloed(id) ? L10n.text("mixer.solo.on") : L10n.text("mixer.solo.off") }
+    func toggleSoloAndAnnounce(_ id: Int32) -> String {
+        toggleSolo(id)
+        return isSoloed(id) ? L10n.text("mixer.solo.on") : L10n.text("mixer.solo.off")
+    }
+
+    static func panDescription(_ pan: Double) -> String {
+        let pct = Int((abs(pan) * 100).rounded())
+        if pct == 0 { return L10n.text("mixer.pan.center") }
+        return pan < 0 ? L10n.format("mixer.pan.left", pct) : L10n.format("mixer.pan.right", pct)
+    }
+}
+#endif

--- a/App/ttaccessible/AppKit/ChannelMixerKeyboardController.swift
+++ b/App/ttaccessible/AppKit/ChannelMixerKeyboardController.swift
@@ -88,7 +88,16 @@ final class ChannelMixerKeyboardController {
             return true
         }
 
-        // Everything else needs a focused user strip.
+        // Everything else needs a focused user strip — but resolving it is up to ~8
+        // system-wide AXUIElementCopyAttributeValue calls, far too costly to run on
+        // every keystroke (and key-repeat). Only the plain arrows and v/p/m/s act on a
+        // strip, so gate the AX walk on those; typing, modified keys and unrelated
+        // shortcuts pass straight through without paying for the IPC.
+        guard plain else { return false }
+        let isMixerKey = arrow != nil
+            || ((event.charactersIgnoringModifiers?.lowercased()).map { ["v", "p", "m", "s"].contains($0) } ?? false)
+        guard isMixerKey else { return false }
+
         guard let uid = findFocusedStripUserID(), coordinator != nil else {
             arrowRepeat.stop(); return false
         }

--- a/App/ttaccessible/AppKit/ChannelMixerKeyboardController.swift
+++ b/App/ttaccessible/AppKit/ChannelMixerKeyboardController.swift
@@ -1,0 +1,249 @@
+//
+//  ChannelMixerKeyboardController.swift
+//  ttaccessible
+//
+//  The Channel Mixer's keyboard model, matching Rocco's Mixer app: a local NSEvent
+//  monitor that, while VoiceOver is focused on a mixer strip, routes
+//    Cmd+Up/Down  -> the focused user's media-file volume (master output volume when
+//                    the cursor is OUTSIDE the mixer)
+//    Up/Down      -> the focused user's voice volume
+//    Left/Right   -> the focused user's pan
+//    v / p / m    -> announce volume / pan / mute (single tap); reset 50% / center /
+//                    toggle mute (double tap)
+//  Single/double-tap and key-repeat use the ported KeyCommandHandler / ArrowRepeatHandler.
+//  The focused user is resolved from VoiceOver's AX cursor (the "channel-strip-<id>"
+//  identifier set by the virtual-accessibility tree), so plain arrows are only hijacked
+//  while the cursor is inside the mixer — elsewhere they pass through untouched. Cmd+Up/Down
+//  is the exception: off a strip it adjusts master output volume.
+//
+
+#if os(macOS)
+import AppKit
+
+@MainActor
+final class ChannelMixerKeyboardController {
+    private weak var coordinator: ChannelMixerCoordinator?
+    /// Adjust the master/output volume one step (up==true) and return the announcement.
+    private let masterVolumeAdjust: (Bool) -> String?
+
+    private var monitor: Any?
+    private let keyHandler = KeyCommandHandler()
+    private let arrowRepeat = ArrowRepeatHandler()
+
+    init(coordinator: ChannelMixerCoordinator, masterVolumeAdjust: @escaping (Bool) -> String?) {
+        self.coordinator = coordinator
+        self.masterVolumeAdjust = masterVolumeAdjust
+    }
+
+    func start() {
+        stop()
+        monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp]) { [weak self] event in
+            guard let self else { return event }
+            return self.handle(event) ? nil : event
+        }
+    }
+
+    func stop() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+        arrowRepeat.stop()
+    }
+
+    deinit { if let monitor { NSEvent.removeMonitor(monitor) } }
+
+    // MARK: Dispatch
+
+    private func handle(_ event: NSEvent) -> Bool {
+        guard NSApp.isActive else { arrowRepeat.stop(); return false }
+        // Never intercept while typing in a text field.
+        if NSApp.keyWindow?.firstResponder is NSTextView { return false }
+
+        let arrow = arrowKey(from: event)
+
+        if event.type == .keyUp {
+            if let arrow { arrowRepeat.stop(key: arrow) }
+            return false
+        }
+        guard event.type == .keyDown else { return false }
+
+        let mods = event.modifierFlags
+        let cmd = mods.contains(.command)
+        let plain = !cmd && !mods.contains(.option) && !mods.contains(.control)
+
+        // Cmd+Up/Down:
+        //   • on a mixer strip -> that user's media-file volume
+        //   • anywhere else     -> master (output) volume
+        if cmd, !mods.contains(.option), !mods.contains(.control),
+           let arrow, arrow == .up || arrow == .down {
+            if let uid = findFocusedStripUserID() {
+                arrowRepeat.start(key: arrow) { [weak self] in
+                    guard let self, let c = self.coordinator else { return }
+                    self.announce(c.nudgeMedia(uid, up: arrow == .up))
+                }
+            } else {
+                arrowRepeat.start(key: arrow) { [weak self] in
+                    if let text = self?.masterVolumeAdjust(arrow == .up) { self?.announce(text) }
+                }
+            }
+            return true
+        }
+
+        // Everything else needs a focused user strip.
+        guard let uid = findFocusedStripUserID(), coordinator != nil else {
+            arrowRepeat.stop(); return false
+        }
+
+        if plain, let arrow {
+            arrowRepeat.start(key: arrow) { [weak self] in
+                guard let self, let c = self.coordinator else { return }
+                let text: String
+                switch arrow {
+                case .up: text = c.nudgeVoice(uid, up: true)
+                case .down: text = c.nudgeVoice(uid, up: false)
+                case .left: text = c.nudgePan(uid, right: false)
+                case .right: text = c.nudgePan(uid, right: true)
+                }
+                self.announce(text)
+            }
+            return true
+        }
+
+        guard plain, let key = event.charactersIgnoringModifiers?.lowercased() else { return false }
+        switch key {
+        case "v":
+            keyHandler.handle(key: "v",
+                onSingle: { [weak self] in self?.announceFrom { $0.announceVoice(uid) } },
+                onDouble: { [weak self] in self?.announceFrom { $0.resetVoice(uid) } })
+            return true
+        case "p":
+            keyHandler.handle(key: "p",
+                onSingle: { [weak self] in self?.announceFrom { $0.announcePan(uid) } },
+                onDouble: { [weak self] in self?.announceFrom { $0.resetPan(uid) } })
+            return true
+        case "m":
+            keyHandler.handle(key: "m",
+                onSingle: { [weak self] in self?.announceFrom { $0.muteState(uid) } },
+                onDouble: { [weak self] in self?.announceFrom { $0.toggleMuteAndAnnounce(uid) } })
+            return true
+        case "s":
+            keyHandler.handle(key: "s",
+                onSingle: { [weak self] in self?.announceFrom { $0.soloState(uid) } },
+                onDouble: { [weak self] in self?.announceFrom { $0.toggleSoloAndAnnounce(uid) } })
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func announceFrom(_ make: (ChannelMixerCoordinator) -> String) {
+        guard let coordinator else { return }
+        announce(make(coordinator))
+    }
+
+    private func announce(_ text: String) {
+        // .priority must be the NSNumber rawValue, not the enum, or VoiceOver drops it.
+        // Keyboard edits aren't VO actions, so this explicit announcement is the only speech.
+        NSAccessibility.post(element: NSApp as Any, notification: .announcementRequested,
+                             userInfo: [.announcement: text,
+                                        .priority: NSAccessibilityPriorityLevel.high.rawValue])
+    }
+
+    private func arrowKey(from event: NSEvent) -> ArrowKey? {
+        guard let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first else { return nil }
+        switch Int(scalar.value) {
+        case NSUpArrowFunctionKey: return .up
+        case NSDownArrowFunctionKey: return .down
+        case NSLeftArrowFunctionKey: return .left
+        case NSRightArrowFunctionKey: return .right
+        default: return nil
+        }
+    }
+
+    /// Walk the AX parent chain of VoiceOver's focused element for a "channel-strip-<id>".
+    private func findFocusedStripUserID() -> Int32? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focused) == .success,
+              let value = focused, CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+        var current: AXUIElement? = unsafeBitCast(value, to: AXUIElement.self)
+        let prefix = "channel-strip-"
+        for _ in 0..<8 {
+            guard let elem = current else { break }
+            var ident: CFTypeRef?
+            if AXUIElementCopyAttributeValue(elem, kAXIdentifierAttribute as CFString, &ident) == .success,
+               let id = ident as? String, id.hasPrefix(prefix),
+               let uid = Int32(id.dropFirst(prefix.count)) {
+                return uid
+            }
+            var parent: CFTypeRef?
+            if AXUIElementCopyAttributeValue(elem, kAXParentAttribute as CFString, &parent) == .success,
+               let p = parent, CFGetTypeID(p) == AXUIElementGetTypeID() {
+                current = unsafeBitCast(p, to: AXUIElement.self)
+            } else {
+                break
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - Ported timing helpers (from Rocco's Mixer app)
+
+enum ArrowKey { case up, down, left, right }
+
+/// Single vs double-tap discrimination for the v/p/m keys (0.35s window).
+@MainActor
+final class KeyCommandHandler {
+    private var pending: [String: DispatchWorkItem] = [:]
+    private var lastPress: [String: TimeInterval] = [:]
+    private let doubleTapInterval: TimeInterval = 0.35
+
+    func handle(key: String, onSingle: @escaping () -> Void, onDouble: @escaping () -> Void) {
+        let now = CACurrentMediaTime()
+        if let last = lastPress[key], now - last <= doubleTapInterval {
+            pending[key]?.cancel(); pending[key] = nil; lastPress[key] = 0
+            onDouble()
+            return
+        }
+        lastPress[key] = now
+        let work = DispatchWorkItem { [weak self] in
+            self?.lastPress[key] = 0
+            onSingle()
+        }
+        pending[key] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + doubleTapInterval, execute: work)
+    }
+}
+
+/// Key-repeat for the arrow keys (0.3s initial delay, then 0.15s).
+@MainActor
+final class ArrowRepeatHandler {
+    private var pending: DispatchWorkItem?
+    private var timer: Timer?
+    private var activeKey: ArrowKey?
+    private let initialDelay: TimeInterval = 0.3
+    private let repeatInterval: TimeInterval = 0.15
+
+    func start(key: ArrowKey, action: @escaping () -> Void) {
+        if activeKey == key { return }
+        stop()
+        activeKey = key
+        action()
+        guard activeKey == key else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.timer = Timer.scheduledTimer(withTimeInterval: self.repeatInterval, repeats: true) { _ in action() }
+        }
+        pending = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + initialDelay, execute: work)
+    }
+
+    func stop(key: ArrowKey) { guard activeKey == key else { return }; stop() }
+
+    func stop() {
+        pending?.cancel(); pending = nil
+        timer?.invalidate(); timer = nil
+        activeKey = nil
+    }
+}
+#endif

--- a/App/ttaccessible/AppKit/ChannelMixerView.swift
+++ b/App/ttaccessible/AppKit/ChannelMixerView.swift
@@ -1,0 +1,73 @@
+//
+//  ChannelMixerView.swift
+//  ttaccessible
+//
+//  The VISIBLE (sighted / mouse) rendering of the Channel Mixer: one row per user with
+//  voice + media volume, pan, mute and solo. It renders the coordinator's published
+//  snapshot and drives the same coordinator methods. VoiceOver does NOT use this — the
+//  virtual-accessibility overlay (MixerVirtualAccessibility) is the screen-reader
+//  interface — so the whole view is accessibilityHidden on macOS.
+//
+
+import SwiftUI
+
+struct ChannelMixerView: View {
+    @ObservedObject var coordinator: ChannelMixerCoordinator
+
+    var body: some View {
+        Group {
+            if coordinator.displayStrips.isEmpty {
+                Text(L10n.text("mixer.empty"))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(coordinator.displayStrips) { strip in
+                        MixerStripRow(strip: strip, coordinator: coordinator)
+                        if strip.id != coordinator.displayStrips.last?.id { Divider() }
+                    }
+                }
+            }
+        }
+        .accessibilityHidden(true)   // VoiceOver uses the virtual-accessibility overlay
+    }
+}
+
+private struct MixerStripRow: View {
+    let strip: MixerDisplayStrip
+    @ObservedObject var coordinator: ChannelMixerCoordinator
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(strip.name).font(.headline)
+
+            fader(L10n.text("mixer.voice.label.short"), value: strip.voicePercent, range: 0...100,
+                  set: { coordinator.setVoice(id: strip.id, percent: $0) },
+                  display: { "\(Int($0.rounded()))%" })
+            fader(L10n.text("mixer.media.label.short"), value: strip.mediaPercent, range: 0...100,
+                  set: { coordinator.setMedia(id: strip.id, percent: $0) },
+                  display: { "\(Int($0.rounded()))%" })
+            fader(L10n.text("mixer.pan.label.short"), value: strip.pan, range: -1...1,
+                  set: { coordinator.setPan(id: strip.id, value: $0) },
+                  display: { ChannelMixerCoordinator.panDescription($0) })
+
+            HStack(spacing: 16) {
+                Toggle(L10n.text("mixer.mute.label.short"), isOn: Binding(
+                    get: { strip.muted }, set: { _ in coordinator.toggleMute(strip.id) }))
+                Toggle(L10n.text("mixer.solo.action.solo"), isOn: Binding(
+                    get: { strip.soloed }, set: { _ in coordinator.toggleSolo(strip.id) }))
+            }
+            .toggleStyle(.checkbox)
+        }
+    }
+
+    private func fader(_ title: String, value: Double, range: ClosedRange<Double>,
+                       set: @escaping (Double) -> Void, display: @escaping (Double) -> String) -> some View {
+        HStack(spacing: 8) {
+            Text(title).frame(width: 96, alignment: .leading)
+            Slider(value: Binding(get: { value }, set: set), in: range)
+            Text(display(value)).monospacedDigit().frame(width: 72, alignment: .trailing)
+        }
+    }
+}

--- a/App/ttaccessible/AppKit/ConnectedServerOutlineView.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerOutlineView.swift
@@ -29,6 +29,14 @@ final class ConnectedServerOutlineView: NSOutlineView {
         return actionDelegate?.connectedServerOutlineView(self, menuForRow: row)
     }
 
+    // VO-Espace sur l'arbre (sans interagir) effectue l'action par défaut sur la ligne
+    // sélectionnée, exactement comme la touche Entrée. Sans cela, VO-Espace n'agit que
+    // lorsqu'on a « interagi » avec l'arbre (curseur VoiceOver descendu sur une cellule).
+    override func accessibilityPerformPress() -> Bool {
+        actionDelegate?.connectedServerOutlineViewDidRequestDefaultAction(self)
+        return true
+    }
+
     override func keyDown(with event: NSEvent) {
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
            event.keyCode == 36 || event.keyCode == 76 {

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+ChannelActions.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+ChannelActions.swift
@@ -325,7 +325,10 @@ extension ConnectedServerViewController {
         guard let channel = selectedChannel else {
             return
         }
+        join(channel)
+    }
 
+    func join(_ channel: ConnectedServerChannel) {
         if channel.isCurrentChannel {
             announce(L10n.format("connectedServer.action.alreadyInChannel", displayText(for: .channel(channel))))
             return
@@ -421,17 +424,25 @@ extension ConnectedServerViewController {
     }
 
     func performDefaultAction() {
-        switch selectedNode {
+        guard let node = selectedNode else {
+            return
+        }
+        performDefaultAction(for: node)
+    }
+
+    // Action par défaut sur un nœud explicite (la ligne sous le curseur VoiceOver),
+    // sans dépendre de la sélection : sans interaction le tableau n'a aucune ligne
+    // sélectionnée, mais VO-Espace doit quand même agir sur la ligne pressée.
+    func performDefaultAction(for node: ServerTreeNode) {
+        switch node {
         case .channel(let channel):
             if channel.isCurrentChannel {
                 leaveCurrentChannel(nil)
             } else {
-                joinSelectedChannel(nil)
+                join(channel)
             }
-        case .user:
-            openPrivateConversation(nil)
-        case .none:
-            return
+        case .user(let user):
+            appDelegate.openPrivateConversation(userID: user.id, displayName: user.displayName)
         }
     }
 

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+Mixer.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+Mixer.swift
@@ -1,0 +1,47 @@
+//
+//  ConnectedServerViewController+Mixer.swift
+//  ttaccessible
+//
+//  Embeds the Channel Mixer as an inline section in the main connected-server window.
+//  The visible heading + (placeholder) area sit alongside the invisible virtual-
+//  accessibility overlay (channelMixerCoordinator.overlay), which is what VoiceOver
+//  navigates: Mixer → per-user strip → controls. Fed by update(session:).
+//
+
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+extension ConnectedServerViewController {
+    func buildChannelMixerSection() -> NSView {
+        // The visible (sighted/mouse) SwiftUI strips, with the invisible virtual-
+        // accessibility overlay laid over them — VoiceOver navigates the overlay, mouse
+        // users see/use the SwiftUI. The overlay supplies the "Mixer / area" label+role.
+        let hosting = NSHostingView(rootView: ChannelMixerView(coordinator: channelMixerCoordinator))
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+
+        let overlay = channelMixerCoordinator.overlay
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(hosting)
+        container.addSubview(overlay)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: container.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            overlay.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            overlay.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            overlay.topAnchor.constraint(equalTo: container.topAnchor),
+            overlay.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+
+        // Install the mixer keyboard model (Cmd+arrows master, arrows volume/pan, p/v/m/s).
+        // The monitor only acts while VoiceOver is focused inside the mixer.
+        channelMixerKeyboardController.start()
+        return container
+    }
+}
+#endif

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+OutlineDelegate.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+OutlineDelegate.swift
@@ -102,14 +102,21 @@ extension ConnectedServerViewController: NSOutlineViewDelegate {
         guard let node = item as? ServerTreeNode else { return nil }
 
         let identifier = NSUserInterfaceItemIdentifier("ConnectedServerCell")
-        let textField: NSTextField
+        let textField: PressActionTextField
 
-        if let cell = outlineView.makeView(withIdentifier: identifier, owner: self) as? NSTextField {
+        if let cell = outlineView.makeView(withIdentifier: identifier, owner: self) as? PressActionTextField {
             textField = cell
         } else {
-            textField = NSTextField(labelWithString: "")
+            textField = PressActionTextField(labelWithString: "")
             textField.identifier = identifier
             textField.lineBreakMode = .byTruncatingTail
+        }
+
+        // VO-Espace effectue l'action par défaut sur CE nœud (rejoindre/quitter un salon,
+        // ouvrir un message privé), comme la touche Entrée — indépendamment de la
+        // sélection, car sans interaction l'arbre n'a aucune ligne sélectionnée.
+        textField.onPress = { [weak self] in
+            self?.performDefaultAction(for: node)
         }
 
         let accessLabel = accessibilityText(for: node)

--- a/App/ttaccessible/AppKit/ConnectedServerViewController+UserActions.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController+UserActions.swift
@@ -129,17 +129,14 @@ extension ConnectedServerViewController {
         return slider
     }
 
-    private func makeVolumeValueLabel(value: Double) -> NSTextField {
-        let valueLabel = NSTextField(labelWithString: VolumeSliderHandler.formatPercent(value))
-        valueLabel.font = .monospacedDigitSystemFont(ofSize: NSFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)
-        valueLabel.alignment = .right
+    private func makeVolumeValueLabel(value: Double) -> PercentValueView {
+        let valueLabel = PercentValueView(text: VolumeSliderHandler.formatPercent(value))
         valueLabel.setContentHuggingPriority(.required, for: .horizontal)
-        valueLabel.setAccessibilityElement(false)
         valueLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
         return valueLabel
     }
 
-    private func makeVolumeSliderRow(title: String, slider: NSSlider, valueLabel: NSTextField) -> NSStackView {
+    private func makeVolumeSliderRow(title: String, slider: NSSlider, valueLabel: NSView) -> NSStackView {
         let titleLabel = NSTextField(labelWithString: title)
         titleLabel.setContentHuggingPriority(.required, for: .horizontal)
         titleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 86).isActive = true
@@ -445,6 +442,45 @@ extension ConnectedServerViewController {
     }
 }
 
+/// A label whose text stays on screen but is never exposed to VoiceOver. NSTextField
+/// derives `isAccessibilityElement` from its content, so `setAccessibilityElement(false)`
+/// doesn't reliably suppress it (notably inside an NSAlert, which reads accessory static
+/// text). Hard-overriding the getter does.
+/// Right-aligned percentage readout that DRAWS its text rather than using an NSTextField,
+/// so it stays visible for sighted users but offers VoiceOver no text to read. An NSAlert
+/// reads the value of descendant NSTextFields in its accessory even when they aren't
+/// accessibility elements; a plain drawing view sidesteps that entirely.
+private final class PercentValueView: NSView {
+    var text: String { didSet { needsDisplay = true; invalidateIntrinsicContentSize() } }
+
+    private static let font = NSFont.monospacedDigitSystemFont(
+        ofSize: NSFont.preferredFont(forTextStyle: .body).pointSize, weight: .regular)
+    private var attributes: [NSAttributedString.Key: Any] {
+        [.font: Self.font, .foregroundColor: NSColor.labelColor]
+    }
+
+    init(text: String) {
+        self.text = text
+        super.init(frame: .zero)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func isAccessibilityElement() -> Bool { false }
+
+    override var intrinsicContentSize: NSSize {
+        let size = (text as NSString).size(withAttributes: attributes)
+        return NSSize(width: max(44, ceil(size.width)), height: ceil(size.height))
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let str = text as NSString
+        let size = str.size(withAttributes: attributes)
+        str.draw(at: NSPoint(x: bounds.width - size.width,            // right-aligned
+                             y: (bounds.height - size.height) / 2),   // vertically centered
+                 withAttributes: attributes)
+    }
+}
+
 private class VolumeSliderHandler: NSObject {
     enum Stream {
         case voice
@@ -455,7 +491,7 @@ private class VolumeSliderHandler: NSObject {
     let userID: Int32
     let stream: Stream
     let connectionController: TeamTalkConnectionController
-    weak var valueLabel: NSTextField?
+    weak var valueLabel: PercentValueView?
 
     init(userID: Int32, stream: Stream, connectionController: TeamTalkConnectionController) {
         self.userID = userID
@@ -468,7 +504,7 @@ private class VolumeSliderHandler: NSObject {
         sender.doubleValue = percent
         let formatted = Self.formatPercent(percent)
         sender.setAccessibilityValueDescription(formatted)
-        valueLabel?.stringValue = formatted
+        valueLabel?.text = formatted
         let clamped = TeamTalkConnectionController.userVolumeFromPercent(percent)
         switch stream {
         case .voice:

--- a/App/ttaccessible/AppKit/ConnectedServerViewController.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController.swift
@@ -61,6 +61,12 @@ final class ConnectedServerViewController: NSViewController {
     let microphoneButton = NSButton(title: "", target: nil, action: nil)
     private var lastAnnouncedMicrophoneStatus: String?
     let collapsibleVideoPanel = CollapsibleVideoPanelView()
+    lazy var channelMixerCoordinator = ChannelMixerCoordinator(controller: connectionController)
+    lazy var channelMixerSectionView: NSView = buildChannelMixerSection()
+    lazy var channelMixerKeyboardController = ChannelMixerKeyboardController(
+        coordinator: channelMixerCoordinator,
+        masterVolumeAdjust: { [weak self] up in self?.outputGainControl.adjustAndDescribe(up: up) }
+    )
     let embeddedMediaStreamingControls = MediaStreamingPlayerViewController()
     var lastVideoDisplayState = VideoDisplayState.empty
     lazy var inputGainControl = AudioGainControlView(
@@ -74,6 +80,12 @@ final class ConnectedServerViewController: NSViewController {
         accessibilityLabel: L10n.text("connectedServer.audio.outputGain.accessibilityLabel")
     ) { [weak self] value in
         self?.applyOutputGain(value)
+    }
+    lazy var soundEffectsGainControl = AudioGainControlView(
+        title: L10n.text("connectedServer.audio.soundEffectsGain.label"),
+        accessibilityLabel: L10n.text("connectedServer.audio.soundEffectsGain.accessibilityLabel")
+    ) { [weak self] value in
+        self?.applySoundEffectsGain(value)
     }
     lazy var contextMenu: NSMenu = makeContextMenu()
 
@@ -153,6 +165,7 @@ final class ConnectedServerViewController: NSViewController {
     func update(session: ConnectedServerSession) {
         applySession(session, preserveSelection: true)
         startRelativeTimestampTimerIfNeeded()
+        channelMixerCoordinator.update(session: session)
     }
 
     func showReconnecting() {
@@ -448,6 +461,7 @@ final class ConnectedServerViewController: NSViewController {
         let audioControlsStack = NSStackView(views: [
             outputGainControl,
             inputGainControl,
+            soundEffectsGainControl,
             embeddedMediaStreamingControls.view
         ])
         audioControlsStack.orientation = .vertical
@@ -463,6 +477,7 @@ final class ConnectedServerViewController: NSViewController {
             channelsScrollView,
             collapsibleVideoPanel,
             audioControlsStack,
+            channelMixerSectionView,
             chatTitleLabel,
             chatScrollView,
             inputStack,
@@ -484,9 +499,11 @@ final class ConnectedServerViewController: NSViewController {
             channelsScrollView.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
             channelsScrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 200),
             collapsibleVideoPanel.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
+            channelMixerSectionView.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
             audioControlsStack.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
             outputGainControl.widthAnchor.constraint(equalTo: audioControlsStack.widthAnchor),
             inputGainControl.widthAnchor.constraint(equalTo: audioControlsStack.widthAnchor),
+            soundEffectsGainControl.widthAnchor.constraint(equalTo: audioControlsStack.widthAnchor),
             embeddedMediaStreamingControls.view.widthAnchor.constraint(equalTo: audioControlsStack.widthAnchor),
             chatScrollView.widthAnchor.constraint(equalTo: mainStack.widthAnchor),
             chatScrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 160),
@@ -698,6 +715,7 @@ final class ConnectedServerViewController: NSViewController {
         }
         inputGainControl.setValue(session.inputGainDB)
         outputGainControl.setValue(session.outputGainDB)
+        soundEffectsGainControl.setValue(preferencesStore.preferences.soundEffectsGainDB)
     }
 
     func applyIncrementalTableUpdate<T: Equatable>(
@@ -874,6 +892,13 @@ final class ConnectedServerViewController: NSViewController {
             mediaStreamingHasVideo: session.mediaStreamingHasVideo
         )
         updateAudioControls()
+    }
+
+    func applySoundEffectsGain(_ value: Double) {
+        // Sound-effects level is a global preference (not per-session), so it just
+        // persists to the store, which pushes the new level to the SoundPlayer.
+        let normalized = AppPreferences.clampGainDB(value)
+        preferencesStore.updateSoundEffectsGainDB(normalized)
     }
 
     func promptBroadcastMessage() {

--- a/App/ttaccessible/AppKit/ConnectedServerViewController.swift
+++ b/App/ttaccessible/AppKit/ConnectedServerViewController.swift
@@ -15,6 +15,20 @@ final class ServerTreeRowView: NSTableRowView {
     override func accessibilityCustomActions() -> [NSAccessibilityCustomAction]? { nil }
 }
 
+// Cellule d'étiquette qui transmet l'action « presser » de VoiceOver (VO-Espace)
+// à une closure, pour que VO-Espace active une ligne comme le fait la touche Entrée.
+// Sans cela, VO-Espace ne fait rien sur ces étiquettes et seule Entrée permet de
+// rejoindre un serveur / un salon.
+final class PressActionTextField: NSTextField {
+    var onPress: (() -> Void)?
+
+    override func accessibilityPerformPress() -> Bool {
+        guard let onPress else { return super.accessibilityPerformPress() }
+        onPress()
+        return true
+    }
+}
+
 
 final class ConnectedServerViewController: NSViewController {
     enum Column {

--- a/App/ttaccessible/AppKit/MixerVirtualAccessibility.swift
+++ b/App/ttaccessible/AppKit/MixerVirtualAccessibility.swift
@@ -78,74 +78,15 @@ final class VirtualControlView: NSView {
     let config: Config
     private var announceToggle = false
 
-    // Per-instance accessibility identifier so the keyboard handler can map "the element
-    // VoiceOver reports as focused" back to this NSView via a static registry.
-    nonisolated(unsafe) private static var nextRegistryId: UInt64 = 0
-    nonisolated(unsafe) private static var registry: [String: WeakBox] = [:]
-    private final class WeakBox { weak var view: VirtualControlView? }
-    let registryId: String
-
     init(config: Config) {
         self.config = config
-        Self.nextRegistryId &+= 1
-        self.registryId = "vctrl-\(Self.nextRegistryId)"
         super.init(frame: .zero)
-        setAccessibilityIdentifier(registryId)
-        let box = WeakBox()
-        box.view = self
-        Self.registry[registryId] = box
     }
-
-    deinit { Self.registry.removeValue(forKey: registryId) }
-
-    override func accessibilityIdentifier() -> String { registryId }
-
-    /// Resolve "the virtual control VoiceOver thinks is focused" to its VirtualControlView.
-    /// Walks the AX parent chain of the focused element looking for a "vctrl-N" identifier.
-    @MainActor
-    static func findFocusedControl() -> VirtualControlView? {
-        let systemWide = AXUIElementCreateSystemWide()
-        var focused: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focused) == .success,
-              let value = focused,
-              CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
-        var current: AXUIElement? = unsafeBitCast(value, to: AXUIElement.self)
-        for _ in 0..<6 {
-            guard let elem = current else { break }
-            var ident: CFTypeRef?
-            if AXUIElementCopyAttributeValue(elem, kAXIdentifierAttribute as CFString, &ident) == .success,
-               let id = ident as? String,
-               id.hasPrefix("vctrl-"),
-               let view = registry[id]?.view {
-                return view
-            }
-            var parent: CFTypeRef?
-            if AXUIElementCopyAttributeValue(elem, kAXParentAttribute as CFString, &parent) == .success,
-               let p = parent,
-               CFGetTypeID(p) == AXUIElementGetTypeID() {
-                current = unsafeBitCast(p, to: AXUIElement.self)
-            } else {
-                break
-            }
-        }
-        return nil
-    }
-
-    nonisolated(unsafe) static weak var currentFocused: VirtualControlView?
 
     required init?(coder: NSCoder) { nil }
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
-
-    override func setAccessibilityFocused(_ focused: Bool) {
-        super.setAccessibilityFocused(focused)
-        if focused {
-            Self.currentFocused = self
-        } else if Self.currentFocused === self {
-            Self.currentFocused = nil
-        }
-    }
 
     // MARK: Accessibility identity
 
@@ -160,8 +101,8 @@ final class VirtualControlView: NSView {
 
     override func accessibilityRoleDescription() -> String? {
         switch config {
-        case .slider: return "slider"
-        case .toggle: return "button"
+        case .slider: return L10n.text("mixer.control.slider.roleDescription")
+        case .toggle: return L10n.text("mixer.control.button.roleDescription")
         }
     }
 
@@ -331,7 +272,7 @@ final class VirtualStripView: NSView {
 
     override func isAccessibilityElement() -> Bool { true }
     override func accessibilityRole() -> NSAccessibility.Role? { .group }
-    override func accessibilityRoleDescription() -> String? { "channel strip" }
+    override func accessibilityRoleDescription() -> String? { L10n.text("mixer.strip.roleDescription") }
     override func accessibilityIdentifier() -> String { "channel-strip-\(stripId)" }
     override func accessibilityLabel() -> String? { MainActor.assumeIsolated { labelProvider() } }
     override func accessibilityChildren() -> [Any]? { childElements.isEmpty ? nil : childElements }

--- a/App/ttaccessible/AppKit/MixerVirtualAccessibility.swift
+++ b/App/ttaccessible/AppKit/MixerVirtualAccessibility.swift
@@ -1,0 +1,405 @@
+//
+//  MixerVirtualAccessibility.swift
+//  ttaccessible
+//
+//  Ported from Rocco's Mixer app (Shared/Views/VirtualStripAccessibility.swift) so the
+//  Channel Mixer's VoiceOver behaviour matches it exactly. On macOS the on-screen SwiftUI
+//  is accessibilityHidden; THIS invisible parallel NSView tree is what VoiceOver navigates:
+//
+//      Mixer area (A11yVirtualGridOverlayView)
+//        └─ per-user strip (VirtualStripView)            role .group, "channel-strip-<userID>"
+//             └─ controls (VirtualControlView)           sliders + mute toggle
+//
+//  The strip/grid are decoupled from the Mixer app's MixerSession and driven by closures
+//  (MixerStripDescriptor) so they bind to ttAccessible's per-user voice/media/pan/mute.
+//  VirtualControlView's slider/toggle behaviour (increment/decrement/press + the high-
+//  priority .announcementRequested posts) is kept verbatim; the X32 picker/text-edit/
+//  section machinery is omitted (the channel mixer only needs sliders and a mute toggle).
+//
+
+#if os(macOS)
+import AppKit
+
+// MARK: - Control config (closure-driven; knows nothing about the data model)
+
+struct VirtualSliderConfig {
+    let label: String
+    let help: String?
+    let getValue: @MainActor @Sendable () -> Double?
+    let getDisplayString: @Sendable (Double) -> String
+    let setValue: @MainActor @Sendable (Double) -> Void
+    let incrementValue: @Sendable (Double) -> Double
+    let decrementValue: @Sendable (Double) -> Double
+    let minValue: Double
+    let maxValue: Double
+    let resetValue: Double?
+
+    init(label: String,
+         help: String? = nil,
+         getValue: @escaping @MainActor @Sendable () -> Double?,
+         getDisplayString: @escaping @Sendable (Double) -> String,
+         setValue: @escaping @MainActor @Sendable (Double) -> Void,
+         incrementValue: @escaping @Sendable (Double) -> Double,
+         decrementValue: @escaping @Sendable (Double) -> Double,
+         minValue: Double,
+         maxValue: Double,
+         resetValue: Double? = nil) {
+        self.label = label
+        self.help = help
+        self.getValue = getValue
+        self.getDisplayString = getDisplayString
+        self.setValue = setValue
+        self.incrementValue = incrementValue
+        self.decrementValue = decrementValue
+        self.minValue = minValue
+        self.maxValue = maxValue
+        self.resetValue = resetValue
+    }
+}
+
+struct VirtualToggleConfig {
+    let getLabel: @MainActor @Sendable () -> String
+    let getState: @MainActor @Sendable () -> Bool?
+    let setState: @MainActor @Sendable (Bool) -> Void
+    let onAnnouncement: String
+    let offAnnouncement: String
+}
+
+// MARK: - Virtual control view
+
+/// Invisible NSView providing VoiceOver with one interactive control. Configured via
+/// closures — does not know about the data model.
+final class VirtualControlView: NSView {
+    enum Config {
+        case slider(VirtualSliderConfig)
+        case toggle(VirtualToggleConfig)
+    }
+
+    let config: Config
+    private var announceToggle = false
+
+    // Per-instance accessibility identifier so the keyboard handler can map "the element
+    // VoiceOver reports as focused" back to this NSView via a static registry.
+    nonisolated(unsafe) private static var nextRegistryId: UInt64 = 0
+    nonisolated(unsafe) private static var registry: [String: WeakBox] = [:]
+    private final class WeakBox { weak var view: VirtualControlView? }
+    let registryId: String
+
+    init(config: Config) {
+        self.config = config
+        Self.nextRegistryId &+= 1
+        self.registryId = "vctrl-\(Self.nextRegistryId)"
+        super.init(frame: .zero)
+        setAccessibilityIdentifier(registryId)
+        let box = WeakBox()
+        box.view = self
+        Self.registry[registryId] = box
+    }
+
+    deinit { Self.registry.removeValue(forKey: registryId) }
+
+    override func accessibilityIdentifier() -> String { registryId }
+
+    /// Resolve "the virtual control VoiceOver thinks is focused" to its VirtualControlView.
+    /// Walks the AX parent chain of the focused element looking for a "vctrl-N" identifier.
+    @MainActor
+    static func findFocusedControl() -> VirtualControlView? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focused) == .success,
+              let value = focused,
+              CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+        var current: AXUIElement? = unsafeBitCast(value, to: AXUIElement.self)
+        for _ in 0..<6 {
+            guard let elem = current else { break }
+            var ident: CFTypeRef?
+            if AXUIElementCopyAttributeValue(elem, kAXIdentifierAttribute as CFString, &ident) == .success,
+               let id = ident as? String,
+               id.hasPrefix("vctrl-"),
+               let view = registry[id]?.view {
+                return view
+            }
+            var parent: CFTypeRef?
+            if AXUIElementCopyAttributeValue(elem, kAXParentAttribute as CFString, &parent) == .success,
+               let p = parent,
+               CFGetTypeID(p) == AXUIElementGetTypeID() {
+                current = unsafeBitCast(p, to: AXUIElement.self)
+            } else {
+                break
+            }
+        }
+        return nil
+    }
+
+    nonisolated(unsafe) static weak var currentFocused: VirtualControlView?
+
+    required init?(coder: NSCoder) { nil }
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+    override var canBecomeKeyView: Bool { true }
+
+    override func setAccessibilityFocused(_ focused: Bool) {
+        super.setAccessibilityFocused(focused)
+        if focused {
+            Self.currentFocused = self
+        } else if Self.currentFocused === self {
+            Self.currentFocused = nil
+        }
+    }
+
+    // MARK: Accessibility identity
+
+    override func isAccessibilityElement() -> Bool { true }
+
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        switch config {
+        case .slider: return .slider
+        case .toggle: return .button
+        }
+    }
+
+    override func accessibilityRoleDescription() -> String? {
+        switch config {
+        case .slider: return "slider"
+        case .toggle: return "button"
+        }
+    }
+
+    override func accessibilityLabel() -> String? {
+        MainActor.assumeIsolated {
+            switch config {
+            case .slider(let cfg): return cfg.label
+            case .toggle(let cfg):
+                // After a press, temporarily return action text ("Muted") instead of
+                // state text ("Mute, On").
+                if announceToggle {
+                    guard let state = cfg.getState() else { return cfg.getLabel() }
+                    return state ? cfg.onAnnouncement : cfg.offAnnouncement
+                }
+                return cfg.getLabel()
+            }
+        }
+    }
+
+    override func accessibilityValue() -> Any? {
+        MainActor.assumeIsolated {
+            switch config {
+            case .slider(let cfg): return cfg.getValue()
+            case .toggle: return nil
+            }
+        }
+    }
+
+    override func accessibilityValueDescription() -> String? {
+        MainActor.assumeIsolated {
+            switch config {
+            case .slider(let cfg):
+                guard let value = cfg.getValue() else { return "Unknown" }
+                return cfg.getDisplayString(value)
+            case .toggle: return nil
+            }
+        }
+    }
+
+    override func accessibilityHelp() -> String? {
+        switch config {
+        case .slider(let cfg): return cfg.help
+        case .toggle: return nil
+        }
+    }
+
+    override func accessibilityMinValue() -> Any? {
+        switch config {
+        case .slider(let cfg): return cfg.minValue
+        case .toggle: return nil
+        }
+    }
+
+    override func accessibilityMaxValue() -> Any? {
+        switch config {
+        case .slider(let cfg): return cfg.maxValue
+        case .toggle: return nil
+        }
+    }
+
+    // MARK: Actions
+
+    override func accessibilityActionNames() -> [NSAccessibility.Action] {
+        switch config {
+        case .slider: return [.increment, .decrement, .press]
+        case .toggle: return [.press]
+        }
+    }
+
+    override func accessibilityActionDescription(_ action: NSAccessibility.Action) -> String? {
+        switch action {
+        case .increment: return "Increment"
+        case .decrement: return "Decrement"
+        case .press: return "Press"
+        default: return nil
+        }
+    }
+
+    override func accessibilityPerformAction(_ action: NSAccessibility.Action) {
+        switch action {
+        case .press: _ = accessibilityPerformPress()
+        case .increment: _ = accessibilityPerformIncrement()
+        case .decrement: _ = accessibilityPerformDecrement()
+        default: super.accessibilityPerformAction(action)
+        }
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        MainActor.assumeIsolated {
+            switch config {
+            case .slider(let cfg):
+                guard let resetValue = cfg.resetValue else { return false }
+                cfg.setValue(resetValue)
+                let desc = cfg.getDisplayString(resetValue)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    NSAccessibility.post(element: NSApp as Any, notification: .announcementRequested,
+                                         userInfo: [.announcement: desc, .priority: NSAccessibilityPriorityLevel.high])
+                }
+                return true
+            case .toggle(let cfg):
+                guard let current = cfg.getState() else { return false }
+                announceToggle = true
+                cfg.setState(!current)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.announceToggle = false
+                }
+                return true
+            }
+        }
+    }
+
+    override func accessibilityPerformIncrement() -> Bool {
+        MainActor.assumeIsolated {
+            guard case .slider(let cfg) = config, let current = cfg.getValue() else { return false }
+            let newValue = cfg.incrementValue(current)
+            cfg.setValue(newValue)
+            NSAccessibility.post(element: NSApp as Any, notification: .announcementRequested,
+                                 userInfo: [.announcement: cfg.getDisplayString(newValue), .priority: NSAccessibilityPriorityLevel.high])
+            return true
+        }
+    }
+
+    override func accessibilityPerformDecrement() -> Bool {
+        MainActor.assumeIsolated {
+            guard case .slider(let cfg) = config, let current = cfg.getValue() else { return false }
+            let newValue = cfg.decrementValue(current)
+            cfg.setValue(newValue)
+            NSAccessibility.post(element: NSApp as Any, notification: .announcementRequested,
+                                 userInfo: [.announcement: cfg.getDisplayString(newValue), .priority: NSAccessibilityPriorityLevel.high])
+            return true
+        }
+    }
+}
+
+// MARK: - Strip descriptor (one per user)
+
+struct MixerStripDescriptor {
+    let id: Int32                                    // userID; identifier "channel-strip-<id>"
+    let label: @MainActor @Sendable () -> String?    // "<name>, <voice level>, muted"
+    let controls: [VirtualControlView.Config]
+}
+
+// MARK: - Virtual strip view (one user)
+
+/// Invisible NSView for one user strip. VoiceOver enters it to reach the controls.
+final class VirtualStripView: NSView {
+    let stripId: Int32
+    private let labelProvider: @MainActor @Sendable () -> String?
+    private(set) var childElements: [VirtualControlView] = []
+
+    init(descriptor: MixerStripDescriptor) {
+        self.stripId = descriptor.id
+        self.labelProvider = descriptor.label
+        super.init(frame: .zero)
+        setAccessibilityIdentifier("channel-strip-\(descriptor.id)")
+        for cfg in descriptor.controls {
+            let control = VirtualControlView(config: cfg)
+            addSubview(control)
+            childElements.append(control)
+        }
+    }
+
+    required init?(coder: NSCoder) { nil }
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+    override var canBecomeKeyView: Bool { true }
+
+    override func isAccessibilityElement() -> Bool { true }
+    override func accessibilityRole() -> NSAccessibility.Role? { .group }
+    override func accessibilityRoleDescription() -> String? { "channel strip" }
+    override func accessibilityIdentifier() -> String { "channel-strip-\(stripId)" }
+    override func accessibilityLabel() -> String? { MainActor.assumeIsolated { labelProvider() } }
+    override func accessibilityChildren() -> [Any]? { childElements.isEmpty ? nil : childElements }
+}
+
+// MARK: - Grid overlay container (the "Mixer" area)
+
+/// Accessibility-only NSView overlay. VoiceOver navigates the virtual strips/controls;
+/// the visible UI is drawn separately (and accessibilityHidden). Driven by a descriptor
+/// provider so it rebuilds as users join/leave the channel.
+final class A11yVirtualGridOverlayView: NSView {
+    private(set) var virtualStrips: [VirtualStripView] = []
+    private var provider: (@MainActor () -> [MixerStripDescriptor])?
+    private var areaLabel: String = "Mixer"
+    private var areaRoleDescription: String = "area"
+    private var lastStripIds: [Int32] = []
+
+    override init(frame: NSRect) { super.init(frame: frame) }
+    required init?(coder: NSCoder) { nil }
+    override var isFlipped: Bool { true }
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func isAccessibilityElement() -> Bool { true }
+    override func accessibilityRole() -> NSAccessibility.Role? { .group }
+    override func accessibilityRoleDescription() -> String? { areaRoleDescription }
+    override func accessibilityLabel() -> String? { areaLabel }
+    override func accessibilityChildren() -> [Any]? { virtualStrips.isEmpty ? nil : virtualStrips }
+
+    func configure(areaLabel: String, areaRoleDescription: String,
+                   provider: @escaping @MainActor () -> [MixerStripDescriptor]) {
+        self.areaLabel = areaLabel
+        self.areaRoleDescription = areaRoleDescription
+        self.provider = provider
+        rebuildStrips()
+    }
+
+    /// Rebuild the virtual strips when the set of users changes (identity, not just count).
+    func rebuildStrips() {
+        guard let provider else { return }
+        MainActor.assumeIsolated {
+            let descriptors = provider()
+            let ids = descriptors.map { $0.id }
+            if ids == lastStripIds { return }
+            lastStripIds = ids
+            virtualStrips.forEach { $0.removeFromSuperview() }
+            virtualStrips = descriptors.map { descriptor in
+                let strip = VirtualStripView(descriptor: descriptor)
+                addSubview(strip)
+                return strip
+            }
+            needsLayout = true
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        guard !virtualStrips.isEmpty, bounds.width > 0, bounds.height > 0 else { return }
+        // Single vertical column of strips; controls stacked within each strip.
+        let stripHeight = bounds.height / CGFloat(virtualStrips.count)
+        for (i, strip) in virtualStrips.enumerated() {
+            strip.frame = NSRect(x: 0, y: CGFloat(i) * stripHeight, width: bounds.width, height: stripHeight)
+            let children = strip.childElements
+            guard !children.isEmpty else { continue }
+            let childHeight = stripHeight / CGFloat(children.count)
+            for (j, child) in children.enumerated() {
+                child.frame = NSRect(x: 0, y: CGFloat(j) * childHeight, width: bounds.width, height: childHeight)
+            }
+        }
+    }
+}
+#endif

--- a/App/ttaccessible/AppKit/PreferencesWindowController.swift
+++ b/App/ttaccessible/AppKit/PreferencesWindowController.swift
@@ -180,7 +180,14 @@ private final class PreferencesContainerViewController: NSViewController {
     }
 
     func warmupExpensiveDependencies() {
-        audioPreferencesStore.warmup()
+        // NOTE: deliberately NOT warming the audio device catalog here. That probe
+        // calls the SDK's TT_GetSoundDevices, which on a large rig takes ~12 s AND
+        // the SDK serializes sound-system access internally — so a launch-time warm
+        // serialized against the connect's TT_InitSoundOutputDevice and made
+        // connecting take ~12 s. The audio device list is seeded instantly from the
+        // persisted cache, and refreshes when the user actually opens Audio prefs
+        // (AudioPreferencesStore.prepareIfNeeded). Output/input themselves use the
+        // virtual device, so the connection never needs this catalog.
         notificationsPreferencesStore.prepareIfNeeded()
     }
 

--- a/App/ttaccessible/AppKit/PreferencesWindowController.swift
+++ b/App/ttaccessible/AppKit/PreferencesWindowController.swift
@@ -434,6 +434,14 @@ private final class PreferencesSidebarCellView: NSTableCellView {
         nil
     }
 
+    // The row exposes the pane title as its own accessibility label, so don't let
+    // VoiceOver descend into the icon + text field (which made it read e.g.
+    // "Recording, circle image, Recording"). Returning no children leaves just the
+    // single label.
+    override func accessibilityChildren() -> [Any]? {
+        []
+    }
+
     func configure(with pane: PreferencesWindowController.Pane) {
         paneImageView.image = NSImage(systemSymbolName: pane.iconName, accessibilityDescription: nil)
         paneTextField.stringValue = pane.title

--- a/App/ttaccessible/AppKit/PreferencesWindowController.swift
+++ b/App/ttaccessible/AppKit/PreferencesWindowController.swift
@@ -172,6 +172,13 @@ private final class PreferencesContainerViewController: NSViewController {
         selectPane(.general)
     }
 
+    // Escape closes the Preferences window. As the window's content view
+    // controller, this VC is in the responder chain, so an unhandled Escape
+    // (cancelOperation:) bubbles up to here.
+    override func cancelOperation(_ sender: Any?) {
+        view.window?.performClose(nil)
+    }
+
     func warmupExpensiveDependencies() {
         audioPreferencesStore.warmup()
         notificationsPreferencesStore.prepareIfNeeded()
@@ -398,9 +405,13 @@ private final class PreferencesSidebarCellView: NSTableCellView {
 
         paneImageView.translatesAutoresizingMaskIntoConstraints = false
         paneImageView.imageScaling = .scaleProportionallyDown
+        // The row already carries the pane title as its accessibility label, so the
+        // icon and the duplicate text field shouldn't be separate VoiceOver stops.
+        paneImageView.setAccessibilityElement(false)
 
         paneTextField.translatesAutoresizingMaskIntoConstraints = false
         paneTextField.font = .systemFont(ofSize: NSFont.systemFontSize)
+        paneTextField.setAccessibilityElement(false)
 
         addSubview(paneImageView)
         addSubview(paneTextField)

--- a/App/ttaccessible/AppKit/SavedServersTableView.swift
+++ b/App/ttaccessible/AppKit/SavedServersTableView.swift
@@ -28,6 +28,14 @@ final class SavedServersTableView: NSTableView {
         return actionDelegate?.savedServersTableView(self, menuForRow: row)
     }
 
+    // VO-Espace sur le tableau (sans interagir) rejoint la ligne sélectionnée,
+    // exactement comme la touche Entrée. Sans cela, VO-Espace n'agit que lorsqu'on
+    // a « interagi » avec le tableau (curseur VoiceOver descendu sur une cellule).
+    override func accessibilityPerformPress() -> Bool {
+        actionDelegate?.savedServersTableViewDidRequestConnect(self)
+        return true
+    }
+
     override func keyDown(with event: NSEvent) {
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty,
            event.keyCode == 36 || event.keyCode == 76 {

--- a/App/ttaccessible/AppKit/SavedServersViewController.swift
+++ b/App/ttaccessible/AppKit/SavedServersViewController.swift
@@ -338,7 +338,14 @@ final class SavedServersViewController: NSViewController {
     }
 
     func connectSelectedServer() {
-        guard let record = selectedRecord, isConnecting == false else {
+        guard let record = selectedRecord else {
+            return
+        }
+        connect(to: record)
+    }
+
+    func connect(to record: SavedServerRecord) {
+        guard isConnecting == false else {
             return
         }
 
@@ -947,17 +954,24 @@ extension SavedServersViewController: NSTableViewDelegate {
         }
 
         let identifier = NSUserInterfaceItemIdentifier("SavedServersCell-\(tableColumn.identifier.rawValue)")
-        let textField: NSTextField
+        let textField: PressActionTextField
 
-        if let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTextField {
+        if let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? PressActionTextField {
             textField = cell
         } else {
-            textField = NSTextField(labelWithString: value)
+            textField = PressActionTextField(labelWithString: value)
             textField.identifier = identifier
             textField.lineBreakMode = .byTruncatingTail
         }
 
         textField.stringValue = value
+        // VO-Espace rejoint le serveur de CETTE ligne (celle sous le curseur VoiceOver),
+        // indépendamment de la sélection du tableau — sans interaction, le tableau n'a
+        // aucune ligne sélectionnée.
+        textField.onPress = { [weak self] in
+            guard let self, self.records.indices.contains(row) else { return }
+            self.connect(to: self.records[row])
+        }
         return textField
     }
 }

--- a/App/ttaccessible/AppKit/SavedServersWindowController.swift
+++ b/App/ttaccessible/AppKit/SavedServersWindowController.swift
@@ -66,6 +66,7 @@ final class SavedServersWindowController: NSWindowController {
             menuState.$hasSelection.map { _ in () }.eraseToAnyPublisher(),
             menuState.$isMasterMuted.map { _ in () }.eraseToAnyPublisher(),
             menuState.$isRecordingActive.map { _ in () }.eraseToAnyPublisher(),
+            menuState.$isHearMyselfEnabled.map { _ in () }.eraseToAnyPublisher(),
             menuState.$isInChannel.map { _ in () }.eraseToAnyPublisher()
         )
         .receive(on: DispatchQueue.main)
@@ -124,6 +125,13 @@ final class SavedServersWindowController: NSWindowController {
                 )
                 item.isEnabled = menuState.mode == .connectedServer && (recording || menuState.isInChannel)
             case .ttHearMyself:
+                // Mirror the Mute/Recording pattern: VoiceOver reads the toolbar
+                // item's label, so swap it to include "selected" when hearing-myself
+                // is on (plain label when off). Stays an ordinary button.
+                let on = menuState.isHearMyselfEnabled
+                item.label = L10n.text(on ? "toolbar.hearMyself.selected" : "toolbar.hearMyself")
+                item.paletteLabel = item.label
+                item.image = NSImage(systemSymbolName: "ear", accessibilityDescription: item.label)
                 item.isEnabled = menuState.mode == .connectedServer && menuState.isInChannel
             case .ttPreferences:
                 item.isEnabled = true

--- a/App/ttaccessible/AudioRTSupport.h
+++ b/App/ttaccessible/AudioRTSupport.h
@@ -1,0 +1,33 @@
+//
+//  AudioRTSupport.h
+//  ttaccessible
+//
+//  Real-time audio support shims. C11 memory fences for the lock-free
+//  single-producer/single-consumer ring buffer used by the output render
+//  engine (OutputAudioRenderEngine). The producer runs on the TeamTalk serial
+//  queue; the consumer runs on the CoreAudio render thread. These fences give
+//  acquire/release ordering between them without any lock — safe to call from
+//  the real-time render callback (pure CPU fence, no syscall, no allocation).
+//
+//  macOS 14 deployment target predates Swift's Synchronization.Atomic
+//  (macOS 15+), so we expose stdatomic fences to Swift instead.
+//
+
+#ifndef AUDIO_RT_SUPPORT_H
+#define AUDIO_RT_SUPPORT_H
+
+#include <stdatomic.h>
+
+/// Acquire fence: all reads after this see writes published before the
+/// matching release fence on the other thread.
+static inline void ttac_atomic_fence_acquire(void) {
+    atomic_thread_fence(memory_order_acquire);
+}
+
+/// Release fence: publishes all prior writes to the thread that performs the
+/// matching acquire fence.
+static inline void ttac_atomic_fence_release(void) {
+    atomic_thread_fence(memory_order_release);
+}
+
+#endif /* AUDIO_RT_SUPPORT_H */

--- a/App/ttaccessible/Models/AppPreferences.swift
+++ b/App/ttaccessible/Models/AppPreferences.swift
@@ -72,6 +72,7 @@ struct AppPreferences: Codable, Equatable {
         case voiceOverAnnouncements
         case inputGainDB
         case outputGainDB
+        case soundEffectsGainDB
         case savedServersSort
         case autoJoinRootChannel
         case autoReconnect
@@ -155,6 +156,10 @@ struct AppPreferences: Codable, Equatable {
     var voiceOverAnnouncements: VoiceOverAnnouncementPreferences
     var inputGainDB: Double
     var outputGainDB: Double
+    // Base level for app notification sound effects (dB). The effective playback
+    // volume is this gain combined with the output (master) volume, so master
+    // scales the sound effects too.
+    var soundEffectsGainDB: Double
     var savedServersSort: SavedServersSortPreferences
     var recordingFolderBookmark: Data?
     var recordingAudioFileFormat: Int
@@ -185,6 +190,7 @@ struct AppPreferences: Codable, Equatable {
         voiceOverAnnouncements: VoiceOverAnnouncementPreferences = VoiceOverAnnouncementPreferences(),
         inputGainDB: Double = 0,
         outputGainDB: Double = 0,
+        soundEffectsGainDB: Double = 0,
         savedServersSort: SavedServersSortPreferences = SavedServersSortPreferences(),
         autoJoinRootChannel: Bool = true,
         autoReconnect: Bool = true,
@@ -241,6 +247,7 @@ struct AppPreferences: Codable, Equatable {
         self.voiceOverAnnouncements = voiceOverAnnouncements
         self.inputGainDB = Self.clampGainDB(inputGainDB)
         self.outputGainDB = Self.clampGainDB(outputGainDB)
+        self.soundEffectsGainDB = Self.clampGainDB(soundEffectsGainDB)
         self.savedServersSort = savedServersSort
         self.autoJoinRootChannel = autoJoinRootChannel
         self.autoReconnect = autoReconnect
@@ -339,6 +346,7 @@ struct AppPreferences: Codable, Equatable {
         voiceOverAnnouncements = try container.decodeIfPresent(VoiceOverAnnouncementPreferences.self, forKey: .voiceOverAnnouncements) ?? VoiceOverAnnouncementPreferences()
         inputGainDB = Self.clampGainDB(try container.decodeIfPresent(Double.self, forKey: .inputGainDB) ?? 0)
         outputGainDB = Self.clampGainDB(try container.decodeIfPresent(Double.self, forKey: .outputGainDB) ?? 0)
+        soundEffectsGainDB = Self.clampGainDB(try container.decodeIfPresent(Double.self, forKey: .soundEffectsGainDB) ?? 0)
         savedServersSort = try container.decodeIfPresent(SavedServersSortPreferences.self, forKey: .savedServersSort) ?? SavedServersSortPreferences()
         autoJoinRootChannel = try container.decodeIfPresent(Bool.self, forKey: .autoJoinRootChannel) ?? true
         autoReconnect = try container.decodeIfPresent(Bool.self, forKey: .autoReconnect) ?? true
@@ -411,6 +419,7 @@ struct AppPreferences: Codable, Equatable {
         try container.encode(voiceOverAnnouncements, forKey: .voiceOverAnnouncements)
         try container.encode(Self.clampGainDB(inputGainDB), forKey: .inputGainDB)
         try container.encode(Self.clampGainDB(outputGainDB), forKey: .outputGainDB)
+        try container.encode(Self.clampGainDB(soundEffectsGainDB), forKey: .soundEffectsGainDB)
         try container.encode(savedServersSort, forKey: .savedServersSort)
         try container.encode(autoJoinRootChannel, forKey: .autoJoinRootChannel)
         try container.encode(autoReconnect, forKey: .autoReconnect)

--- a/App/ttaccessible/Models/AppPreferences.swift
+++ b/App/ttaccessible/Models/AppPreferences.swift
@@ -11,7 +11,7 @@ struct AppPreferences: Codable, Equatable {
     static func defaultNicknameFromAccount() -> String {
         let fullName = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
         let firstWord = fullName.components(separatedBy: .whitespacesAndNewlines).first ?? ""
-        return firstWord.isEmpty ? "TTAccessible" : firstWord
+        return firstWord.isEmpty ? "tt-Accessible" : firstWord
     }
 
     enum ChannelSortMode: String, Codable, CaseIterable {

--- a/App/ttaccessible/Models/AudioDeviceOption.swift
+++ b/App/ttaccessible/Models/AudioDeviceOption.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-struct AudioDeviceOption: Identifiable, Equatable {
+struct AudioDeviceOption: Identifiable, Equatable, Codable {
     let id: String
     let persistentID: String
     let displayName: String
 }
 
-struct AudioDeviceCatalog: Equatable {
+struct AudioDeviceCatalog: Equatable, Codable {
     let inputDevices: [AudioDeviceOption]
     let outputDevices: [AudioDeviceOption]
 

--- a/App/ttaccessible/Models/ConnectedServerSession.swift
+++ b/App/ttaccessible/Models/ConnectedServerSession.swift
@@ -36,6 +36,11 @@ struct ConnectedServerUser: Equatable, Identifiable {
         if username.isEmpty {
             return nickname
         }
+        // When the nickname and username are effectively the same, show it once
+        // (otherwise VoiceOver reads e.g. "dom (dom)" — the same name twice).
+        if nickname.caseInsensitiveCompare(username) == .orderedSame {
+            return nickname
+        }
         return "\(nickname) (\(username))"
     }
 

--- a/App/ttaccessible/Models/ConnectedServerSession.swift
+++ b/App/ttaccessible/Models/ConnectedServerSession.swift
@@ -106,6 +106,28 @@ enum ServerTreeNode: Equatable {
     case user(ConnectedServerUser)
 }
 
+// ServerTreeNode is the item type backing the channel NSOutlineView, so AppKit calls
+// -hash on it constantly during reloads (heaviest right at connect, when the whole
+// tree populates). Without Hashable, that hits a slow Obj-C reflection fallback —
+// flagged by the runtime as a "severe performance problem" and a CPU drain in exactly
+// the window the audio engine is starting. Hash by identity only (case + id), NOT the
+// channel's recursive children/users (a synthesized hash would deep-traverse the whole
+// subtree). This stays consistent with the synthesized Equatable: equal nodes share the
+// same id, so they hash equally; differing-but-same-id nodes may collide, which Hashable
+// permits. Equality (and thus outline item identity) is unchanged.
+extension ServerTreeNode: Hashable {
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case .channel(let channel):
+            hasher.combine(0)
+            hasher.combine(channel.id)
+        case .user(let user):
+            hasher.combine(1)
+            hasher.combine(user.id)
+        }
+    }
+}
+
 struct FileTransferProgress: Equatable {
     let transferID: Int32
     let fileName: String

--- a/App/ttaccessible/Services/AdvancedMicrophoneAudioEngine.swift
+++ b/App/ttaccessible/Services/AdvancedMicrophoneAudioEngine.swift
@@ -635,11 +635,21 @@ final class AdvancedMicrophoneAudioEngine {
         }
 
         // Write interleaved frames to accumulation buffer.
-        for frame in 0..<frameCount {
-            for ch in 0..<channelCount {
-                let srcPtr = auhalRenderDataPtrs[ch]
-                auhalAccumBuffer[auhalAccumWriteIndex] = srcPtr[frame]
-                auhalAccumWriteIndex += 1
+        // This runs inside the real-time AUHAL IO callback, so it uses raw
+        // pointers instead of array subscripts: Swift's per-element bounds
+        // checks (kept in unoptimized/Debug builds) made this loop miss the
+        // IO deadline at 96kHz, causing HAL overload and audible crackle.
+        auhalAccumBuffer.withUnsafeMutableBufferPointer { accumBuf in
+            auhalRenderDataPtrs.withUnsafeBufferPointer { srcBuf in
+                guard let accum = accumBuf.baseAddress, let srcPtrs = srcBuf.baseAddress else { return }
+                var writeIndex = auhalAccumWriteIndex
+                for frame in 0..<frameCount {
+                    for ch in 0..<channelCount {
+                        accum[writeIndex] = srcPtrs[ch][frame]
+                        writeIndex += 1
+                    }
+                }
+                auhalAccumWriteIndex = writeIndex
             }
         }
 
@@ -660,8 +670,13 @@ final class AdvancedMicrophoneAudioEngine {
         if interleavedBuffer.count < totalSamples {
             interleavedBuffer = [Float](repeating: 0, count: totalSamples)
         }
-        for i in 0..<totalSamples {
-            interleavedBuffer[i] = auhalAccumBuffer[i]
+        // Bulk copy (memcpy) instead of a per-sample bounds-checked loop — same
+        // real-time-deadline reasoning as the interleave loop above.
+        interleavedBuffer.withUnsafeMutableBufferPointer { dst in
+            auhalAccumBuffer.withUnsafeBufferPointer { src in
+                guard let d = dst.baseAddress, let s = src.baseAddress else { return }
+                d.update(from: s, count: totalSamples)
+            }
         }
 
         processInterleavedAudio(interleavedData: &interleavedBuffer, frameCount: frameCount, availableChannels: channelCount)

--- a/App/ttaccessible/Services/AdvancedMicrophonePreviewController.swift
+++ b/App/ttaccessible/Services/AdvancedMicrophonePreviewController.swift
@@ -5,7 +5,9 @@
 //  Created by Mathieu Martin on 18/03/2026.
 //
 
+import AudioToolbox
 import AVFAudio
+import CoreAudio
 import Foundation
 
 @MainActor
@@ -29,7 +31,7 @@ final class AdvancedMicrophonePreviewController {
         captureEngine.isRunning
     }
 
-    func start(configuration: AdvancedMicrophoneAudioConfiguration) throws {
+    func start(configuration: AdvancedMicrophoneAudioConfiguration, outputDeviceID: AudioDeviceID?) throws {
         stop()
 
         // Set up playback first. On duplex devices (e.g. Komplete Audio 6) used as both
@@ -49,6 +51,28 @@ final class AdvancedMicrophonePreviewController {
         }
 
         self.playbackFormat = playbackFormat
+
+        // Route preview monitoring to the user's selected output device instead of
+        // the system default. Mirrors the explicit CurrentDevice binding the
+        // capture AUHAL uses. If it can't be resolved/bound, fall back to the
+        // engine's default output so monitoring still works.
+        if let outputDeviceID, let outputAU = playbackEngine.outputNode.audioUnit {
+            var deviceID = outputDeviceID
+            let status = AudioUnitSetProperty(
+                outputAU,
+                kAudioOutputUnitProperty_CurrentDevice,
+                kAudioUnitScope_Global,
+                0,
+                &deviceID,
+                UInt32(MemoryLayout<AudioDeviceID>.size)
+            )
+            if status == noErr {
+                AudioLogger.log("preview: bound output to device %u", outputDeviceID)
+            } else {
+                AudioLogger.log("preview: failed to bind output device %u (OSStatus %d) — using default", outputDeviceID, Int(status))
+            }
+        }
+
         playbackEngine.connect(playerNode, to: playbackEngine.mainMixerNode, format: playbackFormat)
         playbackEngine.prepare()
 

--- a/App/ttaccessible/Services/AdvancedMicrophoneSettingsStore.swift
+++ b/App/ttaccessible/Services/AdvancedMicrophoneSettingsStore.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import CoreAudio
 import Foundation
 
 @MainActor
@@ -29,7 +30,13 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
         self.preferencesStore = preferencesStore
         self.connectionController = connectionController
 
+        // dropFirst() skips the synchronous emit Combine delivers at
+        // subscription time. That initial emit re-ran the same device
+        // enumeration as the explicit warm-up below — a redundant second
+        // synchronous CoreAudio pass during construction. We only want this
+        // sink to react to *subsequent* preference changes.
         preferencesStore.$preferences
+            .dropFirst()
             .sink { [weak self] _ in
                 self?.refreshState(normalizeIfNeeded: true)
             }
@@ -42,7 +49,15 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
             object: nil
         )
 
-        refreshState(normalizeIfNeeded: true)
+        // The app eagerly constructs this store at launch to warm the
+        // Preferences window, but refreshState() does synchronous CoreAudio
+        // device enumeration that blocked the launch run-loop tick. Defer it so
+        // construction returns immediately; the Audio pane re-runs refresh()
+        // via prepareIfNeeded() before it is ever shown, so nothing user-facing
+        // depends on this having completed synchronously.
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshState(normalizeIfNeeded: true)
+        }
     }
 
     deinit {
@@ -89,6 +104,16 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
             return
         }
 
+        // While connected, the live mic engine owns the input device, so a second
+        // capture can't open. Instead monitor the live mic through the output engine
+        // (it produces sound while the mic is actually capturing/transmitting).
+        if connectionController.isConnected {
+            connectionController.setPreviewMonitor(true)
+            lastErrorMessage = nil
+            isPreviewRunning = true
+            return
+        }
+
         do {
             try startPreview()
             lastErrorMessage = nil
@@ -100,6 +125,7 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
     }
 
     func stopPreview() {
+        connectionController.setPreviewMonitor(false)
         previewController.stop()
         isPreviewRunning = false
     }
@@ -108,7 +134,10 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
         feedbackMessage = nil
         preferencesStore.updateAdvancedInputAudio(preferences, for: deviceInfo?.uid)
         refreshState(normalizeIfNeeded: true)
-        if isPreviewRunning {
+        // Only the local (disconnected) preview needs restarting to pick up new
+        // settings; the connected monitor follows the live engine, which
+        // applyAudioPreferences below reconfigures.
+        if isPreviewRunning && connectionController.isConnected == false {
             do {
                 try startPreview()
                 lastErrorMessage = nil
@@ -186,8 +215,23 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
             for: deviceInfo
         ).preferences
 
+        // Resolve the selected output device so preview monitoring plays through
+        // it (not the system default) and at its native sample rate. The output
+        // preference is a TeamTalk device id, which doesn't translate directly to
+        // a CoreAudio device, so resolveOutputDevice matches by UID then name.
+        let outputPreference = preferencesStore.preferences.preferredOutputDevice
+        let resolvedOutput = outputPreference.usesSystemDefault
+            ? nil
+            : InputAudioDeviceResolver.resolveOutputDevice(
+                persistentID: outputPreference.persistentID,
+                displayName: outputPreference.displayName
+            )
+        let outputDeviceID = resolvedOutput?.deviceID
+        let previewSampleRate = resolvedOutput?.nominalSampleRate
+            ?? (deviceInfo.nominalSampleRate > 0 ? deviceInfo.nominalSampleRate : 48_000)
+
         let targetFormat = AdvancedMicrophoneAudioTargetFormat(
-            sampleRate: deviceInfo.nominalSampleRate > 0 ? deviceInfo.nominalSampleRate : 48_000,
+            sampleRate: previewSampleRate,
             channels: previewChannelCount(for: normalized.preset, availableChannels: deviceInfo.inputChannels),
             txIntervalMSec: 40
         )
@@ -200,7 +244,7 @@ final class AdvancedMicrophoneSettingsStore: ObservableObject {
             echoCancellationEnabled: false
         )
 
-        try previewController.start(configuration: configuration)
+        try previewController.start(configuration: configuration, outputDeviceID: outputDeviceID)
     }
 
     private func previewChannelCount(for preset: InputChannelPreset, availableChannels: Int) -> Int {

--- a/App/ttaccessible/Services/AppPreferencesStore.swift
+++ b/App/ttaccessible/Services/AppPreferencesStore.swift
@@ -12,6 +12,7 @@ import Foundation
 final class AppPreferencesStore: ObservableObject {
     private enum Keys {
         static let preferences = "appPreferences.value"
+        static let audioDeviceCatalog = "audioDeviceCatalog.cache"
     }
 
     @Published private(set) var preferences: AppPreferences
@@ -30,9 +31,89 @@ final class AppPreferencesStore: ObservableObject {
         } else {
             preferences = AppPreferences()
         }
+        // One-time upgrade of device prefs persisted with the old unstable SDK
+        // identifier ("legacy:<nDeviceID>") to the stable CoreAudio UID, so the
+        // picker, the binding layer, and the saved preference all agree and the
+        // selected device survives restarts / hot-plug. Runs before the
+        // SoundPlayer setup below so it picks up the upgraded output ID.
+        migrateAudioDevicePreferencesToStableUIDs()
         SoundPlayer.shared.isEnabled = preferences.soundNotificationsEnabled
+        SoundPlayer.shared.setGains(effectsDB: preferences.soundEffectsGainDB, masterDB: preferences.outputGainDB)
         SoundPlayer.shared.loadPack(preferences.soundPack)
         SoundPlayer.shared.disabledSounds = preferences.disabledSoundEvents
+        SoundPlayer.shared.updateOutputDevice(
+            persistentID: preferences.preferredOutputDevice.persistentID,
+            displayName: preferences.preferredOutputDevice.displayName
+        )
+    }
+
+    /// Upgrade any device preference still keyed by the legacy unstable SDK
+    /// identifier ("legacy:<nDeviceID>", or any value that is not a current
+    /// CoreAudio UID) to the stable `kAudioDevicePropertyDeviceUID`, matched by
+    /// the saved display name. A device that isn't currently present is left
+    /// untouched — the resolver's name fallback still binds it, and it upgrades
+    /// on a future launch when it's plugged in. Idempotent.
+    private func migrateAudioDevicePreferencesToStableUIDs() {
+        let inputs = InputAudioDeviceResolver.availableInputDevices().map { (uid: $0.uid, name: $0.name) }
+        let outputs = InputAudioDeviceResolver.availableOutputDevices().map { (uid: $0.uid, name: $0.name) }
+
+        func upgraded(_ preference: AudioDevicePreference, in devices: [(uid: String, name: String)]) -> AudioDevicePreference? {
+            // Only real device selections — skip system-default and the no-output sentinel.
+            guard preference.usesSystemDefault == false,
+                  preference.usesNoOutput == false,
+                  let persistentID = preference.persistentID else {
+                return nil
+            }
+            // Already a valid current UID → nothing to do (idempotent).
+            if devices.contains(where: { $0.uid == persistentID }) {
+                return nil
+            }
+            // Resolve by the saved display name; leave untouched if the device
+            // isn't present right now.
+            guard let displayName = preference.displayName,
+                  let match = devices.first(where: { $0.name.localizedCaseInsensitiveCompare(displayName) == .orderedSame }) else {
+                return nil
+            }
+            return AudioDevicePreference(persistentID: match.uid, displayName: match.name)
+        }
+
+        var updated = preferences
+        var changed = false
+
+        if let newInput = upgraded(preferences.preferredInputDevice, in: inputs),
+           let newID = newInput.persistentID {
+            let oldID = preferences.preferredInputDevice.persistentID
+            updated.preferredInputDevice = newInput
+            // Carry any per-device advanced-input profile over to the new UID key.
+            if let oldID, oldID != newID,
+               let profile = updated.advancedInputAudioProfiles.profilesByDeviceID.removeValue(forKey: oldID) {
+                updated.advancedInputAudioProfiles.profilesByDeviceID[newID] = profile
+            }
+            changed = true
+        }
+        if let newOutput = upgraded(preferences.preferredOutputDevice, in: outputs) {
+            updated.preferredOutputDevice = newOutput
+            changed = true
+        }
+
+        guard changed else { return }
+        preferences = updated
+        persist(updated)
+        AudioLogger.log("migrateAudioDevicePreferences: upgraded legacy device ID(s) to CoreAudio UID(s)")
+    }
+
+    /// Last device catalog persisted from a successful scan. Used to populate the
+    /// Audio preferences pickers instantly on launch while a fresh CoreAudio scan
+    /// runs in the background — the picker no longer shows a bare "System
+    /// Default" while the scan completes.
+    func cachedAudioDeviceCatalog() -> AudioDeviceCatalog? {
+        guard let data = userDefaults.data(forKey: Keys.audioDeviceCatalog) else { return nil }
+        return try? decoder.decode(AudioDeviceCatalog.self, from: data)
+    }
+
+    func storeCachedAudioDeviceCatalog(_ catalog: AudioDeviceCatalog) {
+        guard catalog != .empty, let data = try? encoder.encode(catalog) else { return }
+        userDefaults.set(data, forKey: Keys.audioDeviceCatalog)
     }
 
     func updateDefaultNickname(_ nickname: String) {
@@ -93,6 +174,11 @@ final class AppPreferencesStore: ObservableObject {
 
     func updatePreferredOutputDevice(_ preference: AudioDevicePreference) {
         mutate { $0.preferredOutputDevice = preference }
+        // Keep notification sounds on the same output device as TeamTalk audio.
+        SoundPlayer.shared.updateOutputDevice(
+            persistentID: preference.persistentID,
+            displayName: preference.displayName
+        )
     }
 
     func advancedInputAudio(for deviceID: String?) -> AdvancedInputAudioPreferences {
@@ -153,7 +239,16 @@ final class AppPreferencesStore: ObservableObject {
     }
 
     func updateOutputGainDB(_ value: Double) {
-        mutate { $0.outputGainDB = AppPreferences.clampGainDB(value) }
+        let clamped = AppPreferences.clampGainDB(value)
+        mutate { $0.outputGainDB = clamped }
+        // Master volume also scales the app sound effects.
+        SoundPlayer.shared.setMasterGainDB(clamped)
+    }
+
+    func updateSoundEffectsGainDB(_ value: Double) {
+        let clamped = AppPreferences.clampGainDB(value)
+        mutate { $0.soundEffectsGainDB = clamped }
+        SoundPlayer.shared.setEffectsGainDB(clamped)
     }
 
     func updateSavedServersSortField(_ field: AppPreferences.SavedServersSortField) {
@@ -480,8 +575,11 @@ final class AudioPreferencesStore: ObservableObject {
     private var hasPrepared = false
     private var isVisible = false
     private var applyWorkItem: DispatchWorkItem?
-    private var lastAppliedInputPreference: AudioDevicePreference
-    private var lastAppliedOutputPreference: AudioDevicePreference
+    // nil means "the applied audio state is unknown" — set after a failed apply
+    // so the dedup guard in scheduleApplyAudioPreferencesIfNeeded never skips a
+    // recovery re-selection (including re-picking the previously-applied device).
+    private var lastAppliedInputPreference: AudioDevicePreference?
+    private var lastAppliedOutputPreference: AudioDevicePreference?
 
     var advancedPreferences: AdvancedInputAudioPreferences {
         advancedSettingsStore.advancedPreferences
@@ -512,7 +610,9 @@ final class AudioPreferencesStore: ObservableObject {
         self.state = State(
             preferredInputDevice: rootStore.preferences.preferredInputDevice,
             preferredOutputDevice: rootStore.preferences.preferredOutputDevice,
-            catalog: .empty,
+            // Seed from the last persisted scan so the pickers populate instantly;
+            // a fresh background scan (see loadCatalogIfNeeded) replaces it.
+            catalog: rootStore.cachedAudioDeviceCatalog() ?? .empty,
             isCatalogLoading: false,
             lastErrorMessage: nil,
             advancedFeedbackMessage: advancedSettingsStore.feedbackMessage,
@@ -624,11 +724,15 @@ final class AudioPreferencesStore: ObservableObject {
             guard let self else { return }
             switch result {
             case .success:
-                let catalog = self.connectionController.refreshAvailableAudioDevices()
-                self.state.catalog = catalog
-                self.state.isCatalogLoading = false
-                self.state.lastErrorMessage = nil
-                self.advancedSettingsStore.refresh()
+                self.connectionController.refreshAvailableAudioDevices { [weak self] catalog in
+                    guard let self else { return }
+                    self.state.catalog = catalog
+                    self.state.isCatalogLoading = false
+                    self.state.lastErrorMessage = nil
+                    self.hasLoadedFreshCatalog = true
+                    self.rootStore.storeCachedAudioDeviceCatalog(catalog)
+                    self.advancedSettingsStore.refresh()
+                }
             case .failure(let error):
                 self.state.isCatalogLoading = false
                 self.state.lastErrorMessage = error.localizedDescription
@@ -688,24 +792,32 @@ final class AudioPreferencesStore: ObservableObject {
         return persistentID
     }
 
+    private var hasLoadedFreshCatalog = false
+
     private func loadCatalogIfNeeded(forceRefresh: Bool) {
-        if forceRefresh == false, state.catalog != .empty || state.isCatalogLoading {
+        // Gate on whether a real scan has happened this session, not on catalog
+        // emptiness — the catalog is seeded non-empty from the persisted cache, so
+        // an emptiness check would never trigger the background refresh.
+        if forceRefresh == false, hasLoadedFreshCatalog || state.isCatalogLoading {
             return
         }
 
         state.isCatalogLoading = true
-        // Enumerate devices off the main thread (the connection controller hops to its
-        // serial queue and delivers back on main). A blocking `queue.sync` here froze the
-        // main runloop at launch when Preferences is preloaded, contending with SDK init.
-        let deliver: (AudioDeviceCatalog) -> Void = { [weak self] catalog in
+        // Enumerate devices off the main thread (the connection controller hops to
+        // its serial queue and delivers back on main). A blocking `queue.sync` here
+        // froze the main runloop at launch when Preferences is preloaded. Our catalog
+        // now comes from CoreAudio directly, so the work delivered here is light.
+        let apply: @MainActor (AudioDeviceCatalog) -> Void = { [weak self] catalog in
             guard let self else { return }
             self.state.catalog = catalog
             self.state.isCatalogLoading = false
+            self.hasLoadedFreshCatalog = true
+            self.rootStore.storeCachedAudioDeviceCatalog(catalog)
         }
         if forceRefresh {
-            connectionController.refreshAvailableAudioDevices(completion: deliver)
+            connectionController.refreshAvailableAudioDevices(completion: apply)
         } else {
-            connectionController.availableAudioDevices(completion: deliver)
+            connectionController.availableAudioDevices(completion: apply)
         }
     }
 
@@ -729,6 +841,13 @@ final class AudioPreferencesStore: ObservableObject {
                     self.lastAppliedOutputPreference = outputPreference
                     self.state.lastErrorMessage = nil
                 case .failure(let error):
+                    // The apply failed, so the audio system is in neither the
+                    // requested nor the previously-applied state. Forget the
+                    // applied prefs so the dedup guard above won't skip a
+                    // recovery re-selection — otherwise re-picking the prior
+                    // device is silently ignored and audio never comes back.
+                    self.lastAppliedInputPreference = nil
+                    self.lastAppliedOutputPreference = nil
                     self.state.lastErrorMessage = error.localizedDescription
                 }
             }

--- a/App/ttaccessible/Services/InputAudioDeviceResolver.swift
+++ b/App/ttaccessible/Services/InputAudioDeviceResolver.swift
@@ -36,7 +36,12 @@ enum InputAudioDeviceResolver {
             return nameMatch
         }
 
-        return defaultInputDevice(from: devices) ?? devices.first
+        // The user explicitly chose a specific input device and it isn't present.
+        // Return nil rather than silently substituting the default / first device —
+        // grabbing the "wrong mic" without telling anyone is worse than reporting the
+        // device as unavailable. This mirrors resolveOutputDevice's no-match semantics;
+        // callers that need a device surface a "device unavailable" error instead.
+        return nil
     }
 
     nonisolated static func availablePresetOptions(for device: InputAudioDeviceInfo?) -> [InputChannelPresetOption] {

--- a/App/ttaccessible/Services/InputAudioDeviceResolver.swift
+++ b/App/ttaccessible/Services/InputAudioDeviceResolver.swift
@@ -146,6 +146,90 @@ enum InputAudioDeviceResolver {
         return deviceID
     }
 
+    struct OutputAudioDeviceInfo: Equatable {
+        let deviceID: AudioDeviceID
+        let uid: String
+        let name: String
+        let nominalSampleRate: Double
+    }
+
+    /// Resolve the user's selected output device to a CoreAudio device so preview
+    /// monitoring can bind to it. The stored preference's persistentID is the
+    /// TeamTalk szDeviceID, which on macOS does NOT translate via
+    /// kAudioHardwarePropertyTranslateUIDToDevice, so we match the CoreAudio
+    /// output device by UID first and fall back to the (shared) device name.
+    nonisolated static func resolveOutputDevice(persistentID: String?, displayName: String?) -> OutputAudioDeviceInfo? {
+        let devices = availableOutputDevices()
+        if let persistentID, persistentID.isEmpty == false,
+           let match = devices.first(where: { $0.uid == persistentID }) {
+            return match
+        }
+        if let displayName, displayName.isEmpty == false,
+           let match = devices.first(where: { $0.name.localizedCaseInsensitiveCompare(displayName) == .orderedSame }) {
+            return match
+        }
+        return nil
+    }
+
+    nonisolated static func availableOutputDevices() -> [OutputAudioDeviceInfo] {
+        let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(systemObjectID, &address, 0, nil, &dataSize) == noErr else {
+            return []
+        }
+        let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
+        var deviceIDs = Array(repeating: AudioObjectID(), count: count)
+        guard AudioObjectGetPropertyData(systemObjectID, &address, 0, nil, &dataSize, &deviceIDs) == noErr else {
+            return []
+        }
+        return deviceIDs.compactMap(makeOutputDeviceInfo(for:))
+    }
+
+    private nonisolated static func makeOutputDeviceInfo(for objectID: AudioObjectID) -> OutputAudioDeviceInfo? {
+        guard outputChannelCount(for: objectID) > 0,
+              let name = stringProperty(objectID: objectID, selector: kAudioObjectPropertyName, scope: kAudioObjectPropertyScopeGlobal),
+              let uid = stringProperty(objectID: objectID, selector: kAudioDevicePropertyDeviceUID, scope: kAudioObjectPropertyScopeGlobal) else {
+            return nil
+        }
+        let sampleRate = doubleProperty(
+            objectID: objectID,
+            selector: kAudioDevicePropertyNominalSampleRate,
+            scope: kAudioObjectPropertyScopeGlobal
+        ) ?? 48_000
+        return OutputAudioDeviceInfo(deviceID: objectID, uid: uid, name: name, nominalSampleRate: sampleRate)
+    }
+
+    private nonisolated static func outputChannelCount(for objectID: AudioObjectID) -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(objectID, &address, 0, nil, &dataSize) == noErr else {
+            return 0
+        }
+        let bufferListPointer = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(dataSize),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer {
+            bufferListPointer.deallocate()
+        }
+        guard AudioObjectGetPropertyData(objectID, &address, 0, nil, &dataSize, bufferListPointer) == noErr else {
+            return 0
+        }
+        let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer.assumingMemoryBound(to: AudioBufferList.self))
+        return bufferList.reduce(0) { partialResult, buffer in
+            partialResult + Int(buffer.mNumberChannels)
+        }
+    }
+
     nonisolated static func contains(_ preset: InputChannelPreset, for device: InputAudioDeviceInfo?) -> Bool {
         guard let device, device.inputChannels > 0 else {
             switch preset {

--- a/App/ttaccessible/Services/OutputAudioRenderEngine.swift
+++ b/App/ttaccessible/Services/OutputAudioRenderEngine.swift
@@ -1,0 +1,682 @@
+//
+//  OutputAudioRenderEngine.swift
+//  ttaccessible
+//
+//  Custom CoreAudio OUTPUT engine — the symmetric counterpart of
+//  AdvancedMicrophoneAudioEngine. The TeamTalk SDK is pointed at the virtual
+//  output device (TT_SOUNDDEVICE_ID_TEAMTALK_VIRTUAL) so it never owns a
+//  physical CoreAudio output device (whose close intermittently deadlocks).
+//
+//  Instead of playing the SDK's pre-mixed "muxed" stream (which includes the
+//  local user's own transmitted voice and can't be split per-person), this
+//  engine MIXES PER USER: each remote user's decoded PCM is fed via
+//  `enqueueUser(...)`, and a mixer sums the users — with per-user volume / pan /
+//  mute — into a stereo ring at the output device rate. The render callback
+//  plays that ring to the selected device. The local user is simply never fed
+//  in, so you never hear yourself; and because we own the mix, per-user controls
+//  (pan/mix/mute) are possible. Switching the output device is a fast rebind of
+//  our AudioUnit — no SDK close, no deadlock.
+//
+//  Threading:
+//  - Producer / control / mix plane: this engine's OWN dedicated serial queue
+//    (`engineQueue`, user-interactive). `enqueueUser`, `pumpMix`, `start`, `stop`,
+//    `switchDevice`, and the per-user settings all run there (serially), so per-user
+//    state is single-threaded and needs no locking. `pumpMix` is driven by a fine
+//    timer ON this queue — NOT piggy-backed on the TeamTalk message loop — so the
+//    occasional heavy channel-tree rebuild (publishSessionLocked) can never stall it.
+//    That decoupling is what lets the output ring stay small (low latency) without
+//    underrunning. The producer (`enqueueUser`) is fed a COPIED PCM buffer from the
+//    message loop, then hops to engineQueue. Master gain/mute setters write atomic
+//    cells directly (read by the render callback) and need no queue.
+//  - Consumer: the CoreAudio render callback (real-time thread).
+//  The only cross-thread state is the mixed-output SPSC ring (ordered with
+//  acquire/release fences) and the master gain/mute/primed cells (benign
+//  single-word; gain is smoothed in the render loop). The render callback never
+//  allocates, locks, or calls into ObjC.
+//
+
+import AudioToolbox
+import CoreAudio
+import Foundation
+
+/// Per-user mix controls (applied on the mix thread). Pan is constant-balance:
+/// -1 = hard left, 0 = center, +1 = hard right.
+struct OutputUserMixSettings: Equatable {
+    var volume: Float = 1      // linear gain
+    var pan: Float = 0         // -1 .. +1
+    var muted: Bool = false
+}
+
+/// Lock-free single-producer / single-consumer ring of interleaved Int16 at the
+/// output device rate. Producer (mix thread) writes `tail`, consumer (RT) writes
+/// `head`; monotonic 64-bit counters index a power-of-two buffer.
+private final class OutputAudioSampleRing {
+    private let buffer: UnsafeMutablePointer<Int16>
+    let capacity: Int
+    private let mask: Int
+    private let headPtr: UnsafeMutablePointer<Int>
+    private let tailPtr: UnsafeMutablePointer<Int>
+
+    init(minimumCapacity: Int) {
+        var cap = 1
+        while cap < minimumCapacity { cap <<= 1 }
+        capacity = cap
+        mask = cap - 1
+        buffer = UnsafeMutablePointer<Int16>.allocate(capacity: cap)
+        buffer.initialize(repeating: 0, count: cap)
+        headPtr = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+        headPtr.initialize(to: 0)
+        tailPtr = UnsafeMutablePointer<Int>.allocate(capacity: 1)
+        tailPtr.initialize(to: 0)
+    }
+
+    func free() {
+        buffer.deallocate()
+        headPtr.deallocate()
+        tailPtr.deallocate()
+    }
+
+    func fillCount() -> Int {
+        let t = tailPtr.pointee
+        ttac_atomic_fence_acquire()
+        let h = headPtr.pointee
+        return t - h
+    }
+
+    @discardableResult
+    func write(_ src: UnsafePointer<Int16>, count: Int) -> Int {
+        let h = headPtr.pointee
+        ttac_atomic_fence_acquire()
+        let t = tailPtr.pointee
+        let free = capacity - (t - h)
+        let toWrite = min(count, free)
+        if toWrite <= 0 { return 0 }
+        var idx = t & mask
+        var remaining = toWrite
+        var srcIdx = 0
+        while remaining > 0 {
+            let chunk = min(remaining, capacity - idx)
+            (buffer + idx).update(from: src + srcIdx, count: chunk)
+            idx = (idx + chunk) & mask
+            srcIdx += chunk
+            remaining -= chunk
+        }
+        ttac_atomic_fence_release()
+        tailPtr.pointee = t + toWrite
+        return toWrite
+    }
+
+    /// Consumer-side (real-time): read up to `maxSamples`; pure memmove, RT-safe.
+    func read(into dst: UnsafeMutablePointer<Int16>, maxSamples: Int) -> Int {
+        let t = tailPtr.pointee
+        ttac_atomic_fence_acquire()
+        let h = headPtr.pointee
+        let avail = t - h
+        let toRead = min(maxSamples, avail)
+        if toRead <= 0 { return 0 }
+        var idx = h & mask
+        var remaining = toRead
+        var dstIdx = 0
+        while remaining > 0 {
+            let chunk = min(remaining, capacity - idx)
+            (dst + dstIdx).update(from: buffer + idx, count: chunk)
+            idx = (idx + chunk) & mask
+            dstIdx += chunk
+            remaining -= chunk
+        }
+        ttac_atomic_fence_release()
+        headPtr.pointee = h + toRead
+        return toRead
+    }
+}
+
+/// One remote user's decoded PCM, resampled to the device rate and queued for
+/// mixing. Touched only on the TeamTalk serial queue.
+private final class PerUserMixSource {
+    private var buffer: ContiguousArray<Int16> = []
+    private var head: Int = 0
+    let channels: Int
+    var settings: OutputUserMixSettings
+    private let primeFrames: Int
+    private let maxFrames: Int
+    private var isPrimed = false
+
+    init(channels: Int, primeFrames: Int, maxFrames: Int, settings: OutputUserMixSettings) {
+        self.channels = max(1, channels)
+        self.primeFrames = max(primeFrames, 1)
+        self.maxFrames = max(maxFrames, primeFrames + 1)
+        self.settings = settings
+    }
+
+    var availableFrames: Int { (buffer.count - head) / channels }
+
+    func append(_ samples: [Int16]) {
+        buffer.append(contentsOf: samples)
+        // Catch-up: never let this source get more than `maxFrames` ahead of the
+        // device clock — that is pure added latency. If it does (the SDK delivered
+        // a burst, or the source clock ran fast), drop the oldest audio down to the
+        // `primeFrames` jitter target so latency stays bounded, instead of pinning
+        // at the cap forever (which caused ~225 ms backlog + constant dropouts).
+        let availFrames = (buffer.count - head) / channels
+        if availFrames > maxFrames {
+            head += (availFrames - primeFrames) * channels
+        }
+        if head > 16_384 {
+            buffer.removeFirst(head)
+            head = 0
+        }
+    }
+
+    /// Jitter-buffer gate: a source must accumulate `primeFrames` before it starts
+    /// mixing, and re-primes after an underrun — so poll/delivery jitter doesn't
+    /// produce per-frame silence gaps. Returns whether to mix this tick.
+    func prepareForMix() -> Bool {
+        if settings.muted { return false }
+        if isPrimed {
+            if availableFrames == 0 { isPrimed = false; return false }
+            return true
+        }
+        if availableFrames >= primeFrames { isPrimed = true; return true }
+        return false
+    }
+
+    /// Pop the next frame as (left, right) source samples (mono is duplicated).
+    /// Returns false if empty.
+    func popFrameLR() -> (Int16, Int16)? {
+        guard buffer.count - head >= channels else { return nil }
+        let base = head
+        head += channels
+        if channels == 1 {
+            let s = buffer[base]
+            return (s, s)
+        }
+        return (buffer[base], buffer[base + 1])
+    }
+}
+
+final class OutputAudioRenderEngine {
+    // MARK: AUHAL / device (serial queue, or while AU stopped)
+    private var auhal: AudioUnit?
+    private var deviceSampleRate: Double = 0
+    private var deviceChannels: Int = 0
+    private let maxFramesPerSlice = 4096
+
+    // MARK: Mixed-output ring (mix thread → RT)
+    private var ring: OutputAudioSampleRing?
+    private var targetFillFrames: Int = 0          // stereo frames
+    private let ringCapacitySamples = 65_536
+    /// Ring latency target. Absorbs pump-timing jitter (the mixer pumps on the
+    /// message-loop tick, which can be delayed by message processing / the periodic
+    /// session publish — those delays were causing the occasional dropout). Per-user
+    /// jitter is handled separately by each source's prime buffer.
+    // Output ring target. The decoupled timer pump removed publish-stall underruns, but
+    // under MULTIPLE users the per-block resampling (e.g. 48k users -> 44.1k device) piles
+    // up on the mix queue and delays the pump, so the ring must absorb that. 20ms was too
+    // tight (choppy with several people); 45ms is the reliable floor. (To reclaim the rest
+    // of the latency safely, move resampling off the mix queue — see the producer.)
+    private let targetFillSeconds = 0.045
+
+    // MARK: Per-user mix sources (serial queue only)
+    private var userSources: [Int32: PerUserMixSource] = [:]
+    private var defaultUserSettings: [Int32: OutputUserMixSettings] = [:]
+    private var mixScratch: [Int16] = []
+    private var perUserPrimeFrames: Int = 0   // per-user jitter-buffer target
+    private var perUserMaxFrames: Int = 0      // per-user catch-up ceiling
+
+    // MARK: Cross-thread cells
+    private let gainCell = UnsafeMutablePointer<Float>.allocate(capacity: 1)   // master linear gain
+    private let muteCell = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
+    private let primedCell = UnsafeMutablePointer<Int32>.allocate(capacity: 1)
+
+    // MARK: RT-only state
+    private let mixChannels = 2                     // the ring is always stereo
+    private var rtDeviceChannels = 0
+    private var rtPull: UnsafeMutablePointer<Int16>?
+    private var rtPullCapacity = 0
+    private var rtPlanePtrs: [UnsafeMutablePointer<Float>?] = []
+    private var currentGain: Float = 1
+    private var gainSmoothCoeff: Float = 0.01
+
+    private var underflowCount = 0
+
+    /// The engine's own serial plane (see Threading note). Decoupled from the TeamTalk
+    /// message loop so the heavy channel-tree rebuild can't stall the mixer pump.
+    private let engineQueue = DispatchQueue(label: "com.ttaccessible.mix-engine", qos: .userInteractive)
+    /// Fine timer on `engineQueue` that drives `pumpMix` (replaces the 20 ms message-loop tick).
+    private var mixTimer: DispatchSourceTimer?
+    private let pumpIntervalMS = 5
+
+    init() {
+        gainCell.initialize(to: 1)
+        muteCell.initialize(to: 0)
+        primedCell.initialize(to: 0)
+    }
+
+    deinit {
+        stopImpl()   // direct (no queue hop) — self is being deallocated
+        gainCell.deallocate()
+        muteCell.deallocate()
+        primedCell.deallocate()
+    }
+
+    var isRunning: Bool { auhal != nil }
+
+    // MARK: - Lifecycle
+
+    func start(deviceID: AudioDeviceID) throws {
+        try engineQueue.sync { try self.startImpl(deviceID: deviceID) }
+    }
+
+    private func startImpl(deviceID: AudioDeviceID) throws {
+        stopImpl()
+
+        var componentDesc = AudioComponentDescription(
+            componentType: kAudioUnitType_Output,
+            componentSubType: kAudioUnitSubType_HALOutput,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0
+        )
+        guard let component = AudioComponentFindNext(nil, &componentDesc) else {
+            throw OutputAudioRenderEngineError.deviceUnavailable
+        }
+        var audioUnit: AudioUnit?
+        guard AudioComponentInstanceNew(component, &audioUnit) == noErr, let au = audioUnit else {
+            throw OutputAudioRenderEngineError.deviceUnavailable
+        }
+
+        var enableIO: UInt32 = 1
+        var status = AudioUnitSetProperty(
+            au, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0,
+            &enableIO, UInt32(MemoryLayout<UInt32>.size)
+        )
+        guard status == noErr else { AudioComponentInstanceDispose(au); throw OutputAudioRenderEngineError.deviceUnavailable }
+        var disableIO: UInt32 = 0
+        status = AudioUnitSetProperty(
+            au, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1,
+            &disableIO, UInt32(MemoryLayout<UInt32>.size)
+        )
+        guard status == noErr else { AudioComponentInstanceDispose(au); throw OutputAudioRenderEngineError.deviceUnavailable }
+
+        var devID = deviceID
+        status = AudioUnitSetProperty(
+            au, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0,
+            &devID, UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        guard status == noErr else { AudioComponentInstanceDispose(au); throw OutputAudioRenderEngineError.deviceUnavailable }
+
+        var nativeASBD = AudioStreamBasicDescription()
+        var asbdSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        status = AudioUnitGetProperty(
+            au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0,
+            &nativeASBD, &asbdSize
+        )
+        guard status == noErr else { AudioComponentInstanceDispose(au); throw OutputAudioRenderEngineError.deviceUnavailable }
+
+        let devChannels = max(Int(nativeASBD.mChannelsPerFrame), 1)
+        let devRate = nativeASBD.mSampleRate > 0 ? nativeASBD.mSampleRate : 48_000
+
+        var feedASBD = AudioStreamBasicDescription(
+            mSampleRate: devRate,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked | kAudioFormatFlagIsNonInterleaved,
+            mBytesPerPacket: UInt32(MemoryLayout<Float>.size),
+            mFramesPerPacket: 1,
+            mBytesPerFrame: UInt32(MemoryLayout<Float>.size),
+            mChannelsPerFrame: UInt32(devChannels),
+            mBitsPerChannel: UInt32(MemoryLayout<Float>.size * 8),
+            mReserved: 0
+        )
+        status = AudioUnitSetProperty(
+            au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0,
+            &feedASBD, UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        )
+        guard status == noErr else { AudioComponentInstanceDispose(au); throw OutputAudioRenderEngineError.deviceUnavailable }
+
+        var maxFrames = UInt32(maxFramesPerSlice)
+        AudioUnitSetProperty(
+            au, kAudioUnitProperty_MaximumFramesPerSlice, kAudioUnitScope_Global, 0,
+            &maxFrames, UInt32(MemoryLayout<UInt32>.size)
+        )
+
+        let pullCapacity = maxFramesPerSlice * mixChannels
+        let pull = UnsafeMutablePointer<Int16>.allocate(capacity: pullCapacity)
+        pull.initialize(repeating: 0, count: pullCapacity)
+
+        let newRing = OutputAudioSampleRing(minimumCapacity: ringCapacitySamples)
+        let targetFrames = min(
+            max(Int(targetFillSeconds * devRate), 64),
+            newRing.capacity / (2 * mixChannels)
+        )
+
+        var callbackStruct = AURenderCallbackStruct(
+            inputProc: outputRenderCallback,
+            inputProcRefCon: Unmanaged.passUnretained(self).toOpaque()
+        )
+        status = AudioUnitSetProperty(
+            au, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0,
+            &callbackStruct, UInt32(MemoryLayout<AURenderCallbackStruct>.size)
+        )
+        guard status == noErr else {
+            pull.deallocate(); newRing.free(); AudioComponentInstanceDispose(au)
+            throw OutputAudioRenderEngineError.deviceUnavailable
+        }
+
+        self.auhal = au
+        self.deviceSampleRate = devRate
+        self.deviceChannels = devChannels
+        self.ring = newRing
+        self.targetFillFrames = targetFrames
+        // Per-user jitter target ~25 ms. The ceiling must sit well ABOVE the normal
+        // block swing — audio arrives in ~40 ms chunks atomically, so the buffer
+        // naturally rises to prime+~40 ms right after each block. A ceiling near that
+        // would drop on every block (choppy). ~120 ms only trips on a real backlog
+        // (a burst / clock drift), dropping back to the jitter target.
+        self.perUserPrimeFrames = max(Int(0.025 * devRate), 64)
+        self.perUserMaxFrames = max(Int(0.120 * devRate), perUserPrimeFrames + 64)
+        self.rtDeviceChannels = devChannels
+        self.rtPull = pull
+        self.rtPullCapacity = pullCapacity
+        self.rtPlanePtrs = [UnsafeMutablePointer<Float>?](repeating: nil, count: max(devChannels, 1))
+        self.currentGain = gainCell.pointee
+        self.gainSmoothCoeff = Float(1.0 - exp(-1.0 / (0.008 * devRate)))
+        self.underflowCount = 0
+        primedCell.pointee = 0
+
+        status = AudioUnitInitialize(au)
+        guard status == noErr else { teardownAfterFailedStart(); throw OutputAudioRenderEngineError.startFailed }
+        status = AudioOutputUnitStart(au)
+        guard status == noErr else {
+            AudioUnitUninitialize(au); teardownAfterFailedStart(); throw OutputAudioRenderEngineError.startFailed
+        }
+
+        AudioLogger.log("OutputAudioRenderEngine: started device rate=%.0f ch=%d targetFill=%d frames", devRate, devChannels, targetFrames)
+        startMixTimer()
+    }
+
+    /// Drive pumpMix from a fine timer on engineQueue (decoupled from the message loop).
+    private func startMixTimer() {
+        stopMixTimer()
+        let timer = DispatchSource.makeTimerSource(queue: engineQueue)
+        timer.schedule(deadline: .now() + .milliseconds(pumpIntervalMS),
+                       repeating: .milliseconds(pumpIntervalMS), leeway: .milliseconds(1))
+        timer.setEventHandler { [weak self] in self?.pumpMix() }
+        mixTimer = timer
+        timer.resume()
+    }
+
+    private func stopMixTimer() {
+        mixTimer?.cancel()
+        mixTimer = nil
+    }
+
+    private func teardownAfterFailedStart() {
+        if let au = auhal { AudioComponentInstanceDispose(au) }
+        auhal = nil
+        rtPull?.deallocate(); rtPull = nil; rtPullCapacity = 0
+        ring?.free(); ring = nil
+        rtDeviceChannels = 0; deviceChannels = 0; deviceSampleRate = 0
+        rtPlanePtrs = []
+    }
+
+    func stop() {
+        engineQueue.sync { self.stopImpl() }
+    }
+
+    private func stopImpl() {
+        stopMixTimer()
+        guard let au = auhal else { return }
+        AudioOutputUnitStop(au)
+        AudioUnitUninitialize(au)
+        AudioComponentInstanceDispose(au)
+        auhal = nil
+
+        let drained = underflowCount
+        rtPull?.deallocate(); rtPull = nil; rtPullCapacity = 0
+        rtPlanePtrs = []
+        ring?.free(); ring = nil
+        userSources.removeAll()
+        deviceChannels = 0; deviceSampleRate = 0; rtDeviceChannels = 0
+        targetFillFrames = 0
+        primedCell.pointee = 0
+
+        AudioLogger.log("OutputAudioRenderEngine: stopped (underflows=%d)", drained)
+    }
+
+    /// Rebind to a new output device (no SDK calls). Per-user sources rebuild
+    /// from the still-enabled TT events within a tick (settings persist in
+    /// `defaultUserSettings`); master gain/mute persist in their cells.
+    func switchDevice(_ deviceID: AudioDeviceID) throws {
+        try engineQueue.sync {
+            guard self.isRunning else { return }
+            try self.startImpl(deviceID: deviceID)
+        }
+    }
+
+    // MARK: - Master gain / mute (serial queue)
+
+    func setMasterGainDB(_ gainDB: Double) {
+        gainCell.pointee = Float(pow(10.0, gainDB / 20.0))
+    }
+
+    func setMuted(_ muted: Bool) {
+        muteCell.pointee = muted ? 1 : 0
+    }
+
+    // MARK: - Per-user controls (engineQueue)
+
+    func setUserSettings(_ settings: OutputUserMixSettings, for userID: Int32) {
+        engineQueue.async { [weak self] in
+            guard let self else { return }
+            self.defaultUserSettings[userID] = settings
+            self.userSources[userID]?.settings = settings
+        }
+    }
+
+    func removeUser(_ userID: Int32) {
+        engineQueue.async { [weak self] in
+            self?.userSources.removeValue(forKey: userID)
+        }
+    }
+
+    func removeAllUsers() {
+        engineQueue.async { [weak self] in
+            self?.userSources.removeAll()
+        }
+    }
+
+    // MARK: - Producer (engineQueue): feed one remote user's decoded PCM
+    //
+    // `pcm` is a COPY made by the caller (the SDK audio block is released right after),
+    // so we can hop to engineQueue without lifetime concerns. Interleaved, frames*channels.
+
+    func enqueueUser(_ userID: Int32, pcm: [Int16], frames: Int, channels: Int, sampleRate: Double) {
+        engineQueue.async { [weak self] in
+            guard let self, self.isRunning, frames > 0, channels > 0, self.deviceSampleRate > 0 else { return }
+
+            let source: PerUserMixSource
+            if let existing = self.userSources[userID], existing.channels == channels {
+                source = existing
+            } else {
+                // Reserved negative keys (e.g. the local "hear myself" monitor) want
+                // minimal buffering for low latency; real users get the normal jitter target.
+                let lowLatency = userID < 0
+                let prime = lowLatency ? max(Int(0.010 * self.deviceSampleRate), 32) : self.perUserPrimeFrames
+                let maxF = lowLatency ? max(Int(0.080 * self.deviceSampleRate), prime + 32) : self.perUserMaxFrames
+                source = PerUserMixSource(
+                    channels: channels,
+                    primeFrames: prime,
+                    maxFrames: maxF,
+                    settings: self.defaultUserSettings[userID] ?? OutputUserMixSettings()
+                )
+                self.userSources[userID] = source
+            }
+
+            if abs(sampleRate - self.deviceSampleRate) < 0.5 {
+                source.append(pcm)
+            } else {
+                let result = AudioPCMResampler.resampleInterleaved(
+                    pcm, frameCount: frames, channels: channels,
+                    inputRate: sampleRate, outputRate: self.deviceSampleRate
+                )
+                source.append(result.samples)
+            }
+        }
+    }
+
+    // MARK: - Mixer (serial queue): top the ring up to target by summing users
+
+    private func pumpMix() {
+        guard let ring, isRunning else { return }
+
+        let fillFrames = ring.fillCount() / mixChannels
+        var produce = targetFillFrames - fillFrames
+        if produce <= 0 {
+            if primedCell.pointee == 0, fillFrames >= targetFillFrames { primedCell.pointee = 1 }
+            return
+        }
+        // Cap a single pump (only the initial fill is large; steady-state tops up ~one tick).
+        produce = min(produce, targetFillFrames)
+
+        let needed = produce * mixChannels
+        if mixScratch.count < needed {
+            mixScratch = [Int16](repeating: 0, count: needed)
+        }
+
+        // Only mix sources that are primed (have buffered past their jitter target);
+        // this gate also drops a source mid-tick once it underruns.
+        let active = userSources.values.filter { $0.prepareForMix() }
+        mixScratch.withUnsafeMutableBufferPointer { out in
+            guard let outBase = out.baseAddress else { return }
+            for f in 0..<produce {
+                var left = 0
+                var right = 0
+                for src in active {
+                    guard let (sl, sr) = src.popFrameLR() else { continue }
+                    let (lg, rg) = Self.panGains(volume: src.settings.volume, pan: src.settings.pan)
+                    left += Int(Float(sl) * lg)
+                    right += Int(Float(sr) * rg)
+                }
+                outBase[f * 2] = Int16(clamping: left)
+                outBase[f * 2 + 1] = Int16(clamping: right)
+            }
+            ring.write(outBase, count: needed)
+        }
+
+        if primedCell.pointee == 0, ring.fillCount() / mixChannels >= targetFillFrames {
+            primedCell.pointee = 1
+        }
+    }
+
+    /// Constant-ish balance pan. Returns (leftGain, rightGain) including volume.
+    private static func panGains(volume: Float, pan: Float) -> (Float, Float) {
+        let p = max(-1, min(1, pan))
+        let left = p <= 0 ? 1 : (1 - p)
+        let right = p >= 0 ? 1 : (1 + p)
+        return (volume * left, volume * right)
+    }
+
+    // MARK: - Real-time render
+
+    fileprivate func render(
+        _ ioActionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+        _ inTimeStamp: UnsafePointer<AudioTimeStamp>,
+        _ inBusNumber: UInt32,
+        _ inNumberFrames: UInt32,
+        _ ioData: UnsafeMutablePointer<AudioBufferList>?
+    ) -> OSStatus {
+        guard let ioData else { return noErr }
+        let abl = UnsafeMutableAudioBufferListPointer(ioData)
+        let devCh = rtDeviceChannels
+        let frameCount = Int(inNumberFrames)
+        let srcCh = mixChannels
+        guard devCh > 0, frameCount > 0, devCh <= rtPlanePtrs.count else { return noErr }
+
+        for ch in 0..<devCh {
+            abl[ch].mDataByteSize = UInt32(frameCount * MemoryLayout<Float>.size)
+        }
+
+        let ready = primedCell.pointee != 0
+            && frameCount * srcCh <= rtPullCapacity
+            && ring != nil
+            && rtPull != nil
+
+        let target: Float = (muteCell.pointee != 0) ? 0 : gainCell.pointee
+        let coeff = gainSmoothCoeff
+        let invScale: Float = 1.0 / 32_768.0
+
+        rtPlanePtrs.withUnsafeMutableBufferPointer { planesBuf in
+            guard let planes = planesBuf.baseAddress else { return }
+            var allPlanesValid = true
+            for ch in 0..<devCh {
+                let p = abl[ch].mData?.assumingMemoryBound(to: Float.self)
+                planes[ch] = p
+                if p == nil { allPlanesValid = false }
+            }
+
+            guard ready, allPlanesValid, let ring, let pull = rtPull else {
+                for ch in 0..<devCh {
+                    if let plane = planes[ch] { plane.update(repeating: 0, count: frameCount) }
+                }
+                return
+            }
+
+            let pulled = ring.read(into: pull, maxSamples: frameCount * srcCh)
+            let framesAvailable = pulled / srcCh
+            if framesAvailable < frameCount { underflowCount += 1 }
+
+            var g = currentGain
+            for f in 0..<frameCount {
+                g += (target - g) * coeff
+                if f < framesAvailable {
+                    let base = f * srcCh   // stereo source: [L, R]
+                    for ch in 0..<devCh {
+                        guard let plane = planes[ch] else { continue }
+                        let sample: Int16
+                        if devCh == 1 {
+                            sample = Int16(clamping: (Int(pull[base]) + Int(pull[base + 1])) / 2)
+                        } else if ch <= 1 {
+                            sample = pull[base + ch]
+                        } else {
+                            sample = 0   // extra device channels (>2) get silence
+                        }
+                        plane[f] = Float(sample) * invScale * g
+                    }
+                } else {
+                    for ch in 0..<devCh {
+                        if let plane = planes[ch] { plane[f] = 0 }
+                    }
+                }
+            }
+            currentGain = g
+        }
+
+        return noErr
+    }
+}
+
+enum OutputAudioRenderEngineError: LocalizedError {
+    case deviceUnavailable
+    case startFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .deviceUnavailable, .startFailed:
+            return L10n.text("connectedServer.audio.error.outputStartFailed")
+        }
+    }
+}
+
+// MARK: - AUHAL C render callback
+
+private func outputRenderCallback(
+    _ inRefCon: UnsafeMutableRawPointer,
+    _ ioActionFlags: UnsafeMutablePointer<AudioUnitRenderActionFlags>,
+    _ inTimeStamp: UnsafePointer<AudioTimeStamp>,
+    _ inBusNumber: UInt32,
+    _ inNumberFrames: UInt32,
+    _ ioData: UnsafeMutablePointer<AudioBufferList>?
+) -> OSStatus {
+    let engine = Unmanaged<OutputAudioRenderEngine>.fromOpaque(inRefCon).takeUnretainedValue()
+    return engine.render(ioActionFlags, inTimeStamp, inBusNumber, inNumberFrames, ioData)
+}

--- a/App/ttaccessible/Services/OutputAudioRenderEngine.swift
+++ b/App/ttaccessible/Services/OutputAudioRenderEngine.swift
@@ -131,7 +131,7 @@ private final class OutputAudioSampleRing {
 }
 
 /// One remote user's decoded PCM, resampled to the device rate and queued for
-/// mixing. Touched only on the TeamTalk serial queue.
+/// mixing. Touched only on `engineQueue` (the feed hops there from the message loop).
 private final class PerUserMixSource {
     private var buffer: ContiguousArray<Int16> = []
     private var head: Int = 0
@@ -383,6 +383,14 @@ final class OutputAudioRenderEngine {
         self.underflowCount = 0
         primedCell.pointee = 0
 
+        // Publish the RT render state written just above (rtPull / rtPullCapacity /
+        // rtPlanePtrs / rtDeviceChannels / currentGain / ring) with a release fence,
+        // paired with the acquire at the top of render(). On the very first start the
+        // AudioOutputUnitStart below is itself a de-facto barrier, but switchDevice
+        // re-runs startImpl on the SAME engine instance — make the happens-before
+        // explicit instead of relying on the AU start internals.
+        ttac_atomic_fence_release()
+
         status = AudioUnitInitialize(au)
         guard status == noErr else { teardownAfterFailedStart(); throw OutputAudioRenderEngineError.startFailed }
         status = AudioOutputUnitStart(au)
@@ -586,6 +594,9 @@ final class OutputAudioRenderEngine {
         _ ioData: UnsafeMutablePointer<AudioBufferList>?
     ) -> OSStatus {
         guard let ioData else { return noErr }
+        // Acquire the RT render state published by startImpl's release fence before
+        // reading rtDeviceChannels / rtPlanePtrs / rtPullCapacity / rtPull / currentGain.
+        ttac_atomic_fence_acquire()
         let abl = UnsafeMutableAudioBufferListPointer(ioData)
         let devCh = rtDeviceChannels
         let frameCount = Int(inNumberFrames)

--- a/App/ttaccessible/Services/SavedServersMenuState.swift
+++ b/App/ttaccessible/Services/SavedServersMenuState.swift
@@ -33,6 +33,7 @@ final class SavedServersMenuState: ObservableObject {
     @Published private(set) var isSelectedUserChannelOperator = false
     @Published private(set) var isMasterMuted = false
     @Published private(set) var isRecordingActive = false
+    @Published private(set) var isHearMyselfEnabled = false
     @Published private(set) var isMediaStreamingActive = false
     @Published private(set) var selectedUserSubscriptionStates: [UserSubscriptionOption: Bool] = [:]
 
@@ -66,6 +67,7 @@ final class SavedServersMenuState: ObservableObject {
         setSelectedUsersState(hasSelectedUsers: false, hasSingleSelectedUser: false, hasSingleSelectedOtherUser: false, isSelectedUserMuted: false, isSelectedUserMediaFileMuted: false, isSelectedUserChannelOperator: false, states: [:])
         setMasterMuted(false)
         setRecordingActive(false)
+        setHearMyselfEnabled(false)
         setMediaStreamingActive(false)
     }
 
@@ -91,6 +93,10 @@ final class SavedServersMenuState: ObservableObject {
 
     func setRecordingActive(_ value: Bool) {
         if isRecordingActive != value { isRecordingActive = value }
+    }
+
+    func setHearMyselfEnabled(_ value: Bool) {
+        if isHearMyselfEnabled != value { isHearMyselfEnabled = value }
     }
 
     func setMediaStreamingActive(_ value: Bool) {

--- a/App/ttaccessible/Services/SoundPlayer.swift
+++ b/App/ttaccessible/Services/SoundPlayer.swift
@@ -3,7 +3,10 @@
 //  ttaccessible
 //
 
+import AppKit
+import AudioToolbox
 import AVFoundation
+import CoreAudio
 import Foundation
 
 enum NotificationSound: String, CaseIterable, Codable {
@@ -61,14 +64,75 @@ final class SoundPlayer {
         ProfileContext.current.customSoundPacksDirectory
     }
 
-    private var players: [NotificationSound: AVAudioPlayer] = [:]
+    // App notification sounds play through an AVAudioEngine (rather than NSSound)
+    // so the sound-effects + master gain can AMPLIFY a sound past its authored
+    // level — NSSound.volume hard-caps at 1.0, so it can never make a sound louder
+    // than the file itself. Each sound gets a preloaded buffer + its own player
+    // node (so different sounds overlap and replaying one restarts it, matching the
+    // old behavior). Gain up to +12 dB is applied via node volume (≤ unity) or by
+    // scaling the sample buffer (boost, clamped to avoid runaway clipping). The
+    // engine output is pinned to the user's selected device and only runs while
+    // sounds are actually playing (stopped after a short idle), so it never holds
+    // the output device open the way a perpetually-running engine would.
+    private let engine = AVAudioEngine()
+    private var players: [NotificationSound: AVAudioPlayerNode] = [:]
+    private var buffers: [NotificationSound: AVAudioPCMBuffer] = [:]
+    private var graphReady = false
+    // Resolved CoreAudio device the engine output is pinned to. nil = follow the
+    // current system default output (re-resolved each time the engine starts).
+    private var outputDeviceID: AudioDeviceID?
+    private var appliedDeviceID: AudioDeviceID?
+    private var idleStop: DispatchWorkItem?
     private let queue = DispatchQueue(label: "com.math65.ttaccessible.soundplayer")
+    // Maximum amplification above a sound's authored level: +12 dB ≈ 3.98×.
+    private static let maxBoostLinear: Float = 3.981_071_7
+    // Sound-effects level, in dB, split into the dedicated "sound effects" slider
+    // (base) and the output (master) volume. Master scales the effects too. The
+    // combined gain is clamped to [0, maxBoostLinear]. All accessed only on `queue`.
+    private var effectsGainDB: Double = 0
+    private var masterGainDB: Double = 0
+    private var effectsGainLinear: Float = 1
     var isEnabled = true
     var disabledSounds: Set<NotificationSound> = []
     private(set) var currentPack: String = defaultPack
 
     private init() {
         // Don't load sounds here — AppPreferencesStore will call loadPack() with the user's preferred pack.
+    }
+
+    /// Set the dedicated sound-effects base level (dB).
+    func setEffectsGainDB(_ db: Double) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.effectsGainDB = db
+            self.recomputeEffectsGain()
+        }
+    }
+
+    /// Set the output (master) level (dB), which also scales the sound effects.
+    func setMasterGainDB(_ db: Double) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.masterGainDB = db
+            self.recomputeEffectsGain()
+        }
+    }
+
+    /// Set both the sound-effects base level and the master level at once.
+    func setGains(effectsDB: Double, masterDB: Double) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.effectsGainDB = effectsDB
+            self.masterGainDB = masterDB
+            self.recomputeEffectsGain()
+        }
+    }
+
+    /// Recompute the combined linear gain (clamped to allow up to +12 dB of boost).
+    /// Must run on `queue`.
+    private func recomputeEffectsGain() {
+        let linear = Float(pow(10.0, (effectsGainDB + masterGainDB) / 20.0))
+        effectsGainLinear = min(Self.maxBoostLinear, max(0, linear))
     }
 
     func loadPack(_ packName: String) {
@@ -82,12 +146,40 @@ final class SoundPlayer {
         queue.async { [weak self] in
             guard let self else { return }
             self.currentPack = resolvedPackName
-            self.players.removeAll()
+            var newBuffers: [NotificationSound: AVAudioPCMBuffer] = [:]
             for (sound, url) in resolvedURLs {
-                if let player = try? AVAudioPlayer(contentsOf: url) {
-                    player.prepareToPlay()
-                    self.players[sound] = player
+                if let buffer = Self.loadBuffer(url: url) {
+                    newBuffers[sound] = buffer
                 }
+            }
+            self.buffers = newBuffers
+            self.rebuildGraphLocked()
+        }
+    }
+
+    /// Route notification sounds to a specific output device (by CoreAudio UID).
+    /// Pass the user's preferred output preference; nil/empty follows the system
+    /// default. Resolves the TeamTalk/preference identity to a CoreAudio device.
+    func updateOutputDevice(persistentID: String?, displayName: String?) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            var deviceID: AudioDeviceID?
+            if let persistentID, persistentID.isEmpty == false,
+               let info = InputAudioDeviceResolver.resolveOutputDevice(
+                   persistentID: persistentID,
+                   displayName: displayName
+               ) {
+                deviceID = info.deviceID
+            }
+            self.outputDeviceID = deviceID
+            // Re-pin the device. The CurrentDevice property can only be changed
+            // while the engine is stopped, so if it's running, bounce it.
+            if self.engine.isRunning {
+                self.engine.stop()
+                self.appliedDeviceID = nil
+                self.startEngineLocked()
+            } else {
+                self.appliedDeviceID = nil
             }
         }
     }
@@ -95,14 +187,136 @@ final class SoundPlayer {
     func play(_ sound: NotificationSound) {
         guard isEnabled, !disabledSounds.contains(sound) else { return }
         queue.async { [weak self] in
-            guard let player = self?.players[sound] else { return }
-            if player.isPlaying {
-                player.stop()
+            guard let self,
+                  let node = self.players[sound],
+                  let buffer = self.buffers[sound] else { return }
+            self.startEngineLocked()
+            guard self.engine.isRunning else { return }
+
+            let gain = self.effectsGainLinear
+            let bufferToPlay: AVAudioPCMBuffer
+            if gain > 1.0 {
+                // Boost beyond unity by scaling the samples (node volume caps at 1).
+                bufferToPlay = Self.scaledBuffer(buffer, gain: gain) ?? buffer
+                node.volume = 1.0
+            } else {
+                bufferToPlay = buffer
+                node.volume = gain
             }
-            player.currentTime = 0
-            player.prepareToPlay()
-            player.play()
+
+            // Restart this sound if it's already playing (matches NSSound).
+            node.stop()
+            node.scheduleBuffer(bufferToPlay, at: nil, options: [.interrupts], completionHandler: nil)
+            node.play()
+            self.scheduleIdleStop()
         }
+    }
+
+    // MARK: - Engine plumbing (all on `queue`)
+
+    private static func loadBuffer(url: URL) -> AVAudioPCMBuffer? {
+        guard let file = try? AVAudioFile(forReading: url) else { return nil }
+        let format = file.processingFormat
+        let frameCount = AVAudioFrameCount(file.length)
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return nil }
+        do {
+            try file.read(into: buffer)
+        } catch {
+            return nil
+        }
+        return buffer
+    }
+
+    /// Amplified copy of a buffer (float samples × gain, hard-clamped to ±1).
+    private static func scaledBuffer(_ source: AVAudioPCMBuffer, gain: Float) -> AVAudioPCMBuffer? {
+        guard let sourceData = source.floatChannelData,
+              let copy = AVAudioPCMBuffer(pcmFormat: source.format, frameCapacity: source.frameCapacity),
+              let destData = copy.floatChannelData else { return nil }
+        copy.frameLength = source.frameLength
+        let channels = Int(source.format.channelCount)
+        let frames = Int(source.frameLength)
+        for channel in 0..<channels {
+            let src = sourceData[channel]
+            let dst = destData[channel]
+            for index in 0..<frames {
+                let value = src[index] * gain
+                dst[index] = value > 1.0 ? 1.0 : (value < -1.0 ? -1.0 : value)
+            }
+        }
+        return copy
+    }
+
+    /// Rebuild the engine graph for the currently-loaded buffers.
+    private func rebuildGraphLocked() {
+        let wasRunning = engine.isRunning
+        engine.stop()
+        for node in players.values {
+            engine.disconnectNodeOutput(node)
+            engine.detach(node)
+        }
+        players.removeAll()
+        for (sound, buffer) in buffers {
+            let node = AVAudioPlayerNode()
+            engine.attach(node)
+            engine.connect(node, to: engine.mainMixerNode, format: buffer.format)
+            players[sound] = node
+        }
+        graphReady = true
+        appliedDeviceID = nil
+        if wasRunning {
+            startEngineLocked()
+        }
+    }
+
+    /// Pin the engine output to the resolved device and start it if needed.
+    private func startEngineLocked() {
+        guard graphReady, !players.isEmpty else { return }
+        applyDeviceLocked()
+        guard !engine.isRunning else { return }
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            NSLog("SoundPlayer: AVAudioEngine start failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Set the output node's CurrentDevice. Engine must be stopped before calling.
+    private func applyDeviceLocked() {
+        let target = outputDeviceID
+            ?? InputAudioDeviceResolver.defaultOutputDeviceUID()
+                .flatMap { InputAudioDeviceResolver.audioDeviceID(forUID: $0) }
+        guard let target, target != appliedDeviceID,
+              let outputUnit = engine.outputNode.audioUnit else { return }
+        var deviceID = target
+        let status = AudioUnitSetProperty(
+            outputUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        if status == noErr {
+            appliedDeviceID = target
+        }
+    }
+
+    /// Stop the engine ~5 s after the last sound so we don't hold the device open.
+    private func scheduleIdleStop() {
+        idleStop?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            if self.players.values.contains(where: { $0.isPlaying }) {
+                self.scheduleIdleStop()   // something is still playing; check again later
+            } else {
+                self.engine.stop()
+                self.appliedDeviceID = nil
+            }
+        }
+        idleStop = work
+        queue.asyncAfter(deadline: .now() + 5.0, execute: work)
     }
 
     @discardableResult

--- a/App/ttaccessible/Services/SoundPlayer.swift
+++ b/App/ttaccessible/Services/SoundPlayer.swift
@@ -272,8 +272,13 @@ final class SoundPlayer {
     /// Pin the engine output to the resolved device and start it if needed.
     private func startEngineLocked() {
         guard graphReady, !players.isEmpty else { return }
-        applyDeviceLocked()
+        // Re-pin the device ONLY when the engine is stopped: setting
+        // kAudioOutputUnitProperty_CurrentDevice on a running AUHAL is the trap from
+        // CLAUDE.md. The appliedDeviceID dedup makes it benign today, but bail on a
+        // running engine first so it's safe by construction. Every path that actually
+        // starts the engine reaches here stopped, so the device is still pinned pre-start.
         guard !engine.isRunning else { return }
+        applyDeviceLocked()
         engine.prepare()
         do {
             try engine.start()

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Administration.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Administration.swift
@@ -783,6 +783,23 @@ extension TeamTalkConnectionController {
         }
     }
 
+    /// Continuous pan for the Channel Mixer (-1 left .. 0 center .. +1 right) plus the
+    /// engine-level mute used for SOLO (mute everyone NOT soloed). Drives our own per-user
+    /// mix (OutputAudioRenderEngine) for BOTH the user's voice and media-file sources,
+    /// independent of the SDK's discrete left/right stereo and the SDK per-user mute.
+    /// Volume stays at the SDK layer, so the engine gain is left at 1. Pan persisted.
+    func setUserPan(userID: Int32, username: String, pan: Float, engineMuted: Bool = false) {
+        let clamped = max(-1, min(1, pan))
+        userVolumeStore.setPan(clamped, forUsername: username)
+        let mediaKey = outputMediaSourceKey(userID)
+        queue.async { [weak self] in
+            guard let self else { return }
+            let settings = OutputUserMixSettings(volume: 1, pan: clamped, muted: engineMuted)
+            self.outputRenderEngine.setUserSettings(settings, for: userID)
+            self.outputRenderEngine.setUserSettings(settings, for: mediaKey)
+        }
+    }
+
     func getUserStereo(userID: Int32, completion: @escaping @MainActor (Bool, Bool) -> Void) {
         queue.async { [weak self] in
             guard let self, let instance = self.instance else {

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -15,62 +15,67 @@ extension TeamTalkConnectionController {
         case output
     }
 
-    @MainActor
-    func availableAudioDevices() -> AudioDeviceCatalog {
-        if DispatchQueue.getSpecific(key: queueKey) != nil {
-            return availableAudioDevicesLocked(forceRefresh: false)
-        }
-        return queue.sync {
-            availableAudioDevicesLocked(forceRefresh: false)
-        }
-    }
-
-    @MainActor
-    func refreshAvailableAudioDevices() -> AudioDeviceCatalog {
-        if DispatchQueue.getSpecific(key: queueKey) != nil {
-            cachedSoundDevices = []
-            cachedAudioDeviceCatalog = nil
-            return availableAudioDevicesLocked(forceRefresh: true)
-        }
-        return queue.sync {
-            cachedSoundDevices = []
-            cachedAudioDeviceCatalog = nil
-            return availableAudioDevicesLocked(forceRefresh: true)
-        }
-    }
-
-    /// Non-blocking variant of `availableAudioDevices()`. Enumerates devices on the
-    /// TeamTalk serial queue and delivers the catalog on the main thread. Used by
-    /// launch-time Preferences warmup so it never blocks the main runloop with a
-    /// `queue.sync` that contends with SDK init running on the same serial queue.
-    func availableAudioDevices(completion: @escaping (AudioDeviceCatalog) -> Void) {
+    // Build the audio-device catalog on the connection queue and deliver it on
+    // the main actor. The TeamTalk SDK's TT_GetSoundDevices can take many
+    // seconds to probe a large CoreAudio setup (27 devices ≈ 15s on a Pro
+    // Tools / aggregate-heavy rig), so this must never run through a main-thread
+    // queue.sync — doing so froze the app for the entire probe during launch.
+    func availableAudioDevices(completion: @escaping @MainActor (AudioDeviceCatalog) -> Void) {
         queue.async { [weak self] in
             guard let self else {
-                DispatchQueue.main.async { completion(.empty) }
+                Task { @MainActor in completion(.empty) }
                 return
             }
-            let catalog = self.availableAudioDevicesLocked(forceRefresh: false)
-            DispatchQueue.main.async { completion(catalog) }
+            if let cached = self.cachedAudioDeviceCatalog {
+                Task { @MainActor in completion(cached) }
+                return
+            }
+            let catalog = Self.buildCoreAudioCatalog()
+            self.cachedAudioDeviceCatalog = catalog
+            Task { @MainActor in completion(catalog) }
         }
     }
 
-    /// Non-blocking variant of `refreshAvailableAudioDevices()` (forced re-enumeration).
-    func refreshAvailableAudioDevices(completion: @escaping (AudioDeviceCatalog) -> Void) {
+    func refreshAvailableAudioDevices(completion: @escaping @MainActor (AudioDeviceCatalog) -> Void) {
         queue.async { [weak self] in
             guard let self else {
-                DispatchQueue.main.async { completion(.empty) }
+                Task { @MainActor in completion(.empty) }
                 return
             }
-            self.cachedSoundDevices = []
-            self.cachedAudioDeviceCatalog = nil
-            let catalog = self.availableAudioDevicesLocked(forceRefresh: true)
-            DispatchQueue.main.async { completion(catalog) }
+            let catalog = Self.buildCoreAudioCatalog()
+            self.cachedAudioDeviceCatalog = catalog
+            Task { @MainActor in completion(catalog) }
         }
+    }
+
+    /// Build the device-picker catalog directly from CoreAudio, identifying every
+    /// device by its stable `kAudioDevicePropertyDeviceUID`. This is the same
+    /// identity the audio engines actually bind by (see InputAudioDeviceResolver /
+    /// OutputAudioRenderEngine), so the picker, the persisted preference, and the
+    /// binding layer all share ONE stable key. The SDK is bypassed (both
+    /// directions open the TeamTalk virtual device), so its sound-device list —
+    /// whose `nDeviceID` reshuffles across launches/hot-plug and whose
+    /// `szDeviceID` is empty on macOS — is no longer consulted for device
+    /// identity. CoreAudio enumeration is a few ms, so no off-queue probe needed.
+    nonisolated static func buildCoreAudioCatalog() -> AudioDeviceCatalog {
+        func option(uid: String, name: String) -> AudioDeviceOption {
+            AudioDeviceOption(id: uid, persistentID: uid, displayName: name)
+        }
+        let inputDevices = InputAudioDeviceResolver.availableInputDevices()
+            .filter { $0.name.hasPrefix("CADefaultDeviceAggregate") == false }
+            .map { option(uid: $0.uid, name: $0.name) }
+            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+        let outputDevices = InputAudioDeviceResolver.availableOutputDevices()
+            .filter { $0.name.hasPrefix("CADefaultDeviceAggregate") == false }
+            .map { option(uid: $0.uid, name: $0.name) }
+            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+        let catalog = AudioDeviceCatalog(inputDevices: inputDevices, outputDevices: outputDevices)
+        AudioLogger.log("buildCoreAudioCatalog: %d input, %d output", inputDevices.count, outputDevices.count)
+        return catalog
     }
 
     func invalidateAudioDeviceCache() {
         queue.async { [weak self] in
-            self?.cachedSoundDevices = []
             self?.cachedAudioDeviceCatalog = nil
         }
     }
@@ -135,12 +140,12 @@ extension TeamTalkConnectionController {
 
             let hadOutput = self.outputAudioReady
             if hadOutput, let instance = self.instance {
+                self.teardownOutputRenderLocked(instance: instance)
                 _ = TT_CloseSoundOutputDevice(instance)
                 self.outputAudioReady = false
             }
 
             let ok = TT_RestartSoundSystem()
-            self.cachedSoundDevices = []
             self.cachedAudioDeviceCatalog = nil
 
             AudioLogger.log("restartSoundSystem: TT_RestartSoundSystem returned %d", ok)
@@ -163,10 +168,9 @@ extension TeamTalkConnectionController {
             let prefersOutputDevice = !self.preferencesStore.preferences.preferredOutputDevice.usesNoOutput
             if (hadOutput || prefersOutputDevice), let instance = self.instance {
                 do {
+                    // Reopens the virtual output + muxed event; the render engine
+                    // restarts on the next muxed block (gain/mute reapplied inside).
                     try self.ensureDirectOutputAudioReadyLocked(instance: instance)
-                    if self.masterMuted {
-                        _ = TT_SetSoundOutputMute(instance, 1)
-                    }
                 } catch {
                     AudioLogger.log("restartSoundSystem: output re-open failed — %@", error.localizedDescription)
                     DispatchQueue.main.async { completion(.failure(error)) }
@@ -216,9 +220,45 @@ extension TeamTalkConnectionController {
                 return
             }
 
-            let hadActiveAudio = self.outputAudioReady || self.inputAudioReady || self.isAnyMicrophoneEngineRunning
-            if hadActiveAudio {
-                // User-changed routing needs a fresh TeamTalk device list, not just close/reopen.
+            // Fast path: close and reopen just the affected devices (~0.1s, a
+            // brief stutter). This is the behavior that shipped before ee7af8b
+            // rerouted active-audio changes through a full TT_RestartSoundSystem,
+            // which takes ~12s on large device setups (27 devices measured) and
+            // drops ALL audio for the whole call. reinitializeAudioDevicesLocked
+            // is unchanged from that prior version; the cached device list is
+            // valid for routing-only changes (hardware add/remove is handled
+            // separately and refreshes the cache). Fall back to the full restart
+            // only if the fast reopen actually throws.
+            // Only reinitialize the device(s) that actually changed. An input-only
+            // change must NOT close/reopen the output (and vice versa) — both to
+            // avoid a needless playback gap and to keep input switches away from
+            // the intermittent TT_CloseSoundOutputDevice deadlock entirely.
+            let outputChanged = self.appliedOutputPreference == nil
+                || preferences.preferredOutputDevice != self.appliedOutputPreference
+            let inputChanged = self.appliedInputPreference == nil
+                || preferences.preferredInputDevice != self.appliedInputPreference
+
+            guard outputChanged || inputChanged else {
+                self.appliedOutputPreference = preferences.preferredOutputDevice
+                self.appliedInputPreference = preferences.preferredInputDevice
+                DispatchQueue.main.async { completion(.success(())) }
+                return
+            }
+
+            do {
+                try self.reinitializeAudioDevicesLocked(
+                    instance: instance,
+                    preferences: preferences,
+                    reinitInput: inputChanged,
+                    reinitOutput: outputChanged
+                )
+                self.captureAudioRoutingSnapshotLocked()
+                self.publishSessionLocked(instance: instance, record: record)
+                DispatchQueue.main.async {
+                    completion(.success(()))
+                }
+            } catch {
+                AudioLogger.log("applyAudioPreferences: fast reinit failed (%@) — falling back to full sound-system restart", error.localizedDescription)
                 self.restartSoundSystem { [weak self] result in
                     guard let self else { return }
                     switch result {
@@ -230,20 +270,6 @@ extension TeamTalkConnectionController {
                     case .failure(let error):
                         DispatchQueue.main.async { completion(.failure(error)) }
                     }
-                }
-                return
-            }
-
-            do {
-                try self.reinitializeAudioDevicesLocked(instance: instance, preferences: preferences)
-                self.captureAudioRoutingSnapshotLocked()
-                self.publishSessionLocked(instance: instance, record: record)
-                DispatchQueue.main.async {
-                    completion(.success(()))
-                }
-            } catch {
-                DispatchQueue.main.async {
-                    completion(.failure(error))
                 }
             }
         }
@@ -399,6 +425,7 @@ extension TeamTalkConnectionController {
             _ = try advancedMicrophoneEngine.start(configuration: configuration)
             advancedMicrophoneTargetFormat = targetFormat
             inputAudioReady = true
+            appliedInputPreference = preferencesStore.preferences.preferredInputDevice
             lastAudioWarningMessage = nil
 
             // Monitor sample rate changes on the active input device.
@@ -413,7 +440,9 @@ extension TeamTalkConnectionController {
                 if #available(macOS 14.2, *), startSpeakerTapForAEC() {
                     AudioLogger.log("AEC: using speaker tap for reference signal")
                 } else {
-                    // Fallback: use SDK muxed audio (only TeamTalk audio, not VoiceOver/system).
+                    // Fallback (pre-macOS 14.2): use the SDK muxed (remote) stream as
+                    // the AEC far-end reference. Playback uses per-user mixing, so this
+                    // muxed event is for AEC only; handleAudioBlockLocked feeds it.
                     TT_EnableAudioBlockEvent(instance, TT_MUXED_USERID, UInt32(STREAMTYPE_VOICE.rawValue), 1)
                     AudioLogger.log("AEC: using SDK muxed audio for reference signal (fallback)")
                 }
@@ -434,39 +463,74 @@ extension TeamTalkConnectionController {
 
     func reinitializeAudioDevicesLocked(
         instance: UnsafeMutableRawPointer,
-        preferences: AppPreferences
+        preferences: AppPreferences,
+        reinitInput: Bool = true,
+        reinitOutput: Bool = true
     ) throws {
-        AudioLogger.log("reinitializeAudioDevicesLocked: begin")
+        let aecTapActive = speakerTapCaptureStorage != nil
+        AudioLogger.log("reinitializeAudioDevicesLocked: begin (reinitInput=%d reinitOutput=%d voice=%d inputReady=%d outputReady=%d micEngine=%d aecTap=%d virtualInput=%d)",
+            reinitInput ? 1 : 0,
+            reinitOutput ? 1 : 0,
+            voiceTransmissionEnabled ? 1 : 0,
+            inputAudioReady ? 1 : 0,
+            outputAudioReady ? 1 : 0,
+            isAnyMicrophoneEngineRunning ? 1 : 0,
+            aecTapActive ? 1 : 0,
+            teamTalkVirtualInputReady ? 1 : 0)
         let wasVoiceTransmissionEnabled = voiceTransmissionEnabled
         let wasInputAudioReady = inputAudioReady
-        if wasVoiceTransmissionEnabled || wasInputAudioReady || isAnyMicrophoneEngineRunning {
-            stopAdvancedMicrophoneInputLocked(instance: instance, reason: "reinitializeAudioDevicesLocked")
+
+        if reinitInput {
+            if wasVoiceTransmissionEnabled || wasInputAudioReady || isAnyMicrophoneEngineRunning {
+                stopAdvancedMicrophoneInputLocked(instance: instance, reason: "reinitializeAudioDevicesLocked")
+            }
+            AudioLogger.log("reinit: mic input stopped")
+            voiceTransmissionEnabled = false
+            inputAudioReady = false
+            advancedMicrophoneTargetFormat = nil
+
+            if teamTalkVirtualInputReady {
+                AudioLogger.log("reinit: closing virtual input device")
+                _ = TT_CloseSoundInputDevice(instance)
+                AudioLogger.log("reinit: closed virtual input device")
+                teamTalkVirtualInputReady = false
+            }
         }
-        voiceTransmissionEnabled = false
-        inputAudioReady = false
-        advancedMicrophoneTargetFormat = nil
 
-        if teamTalkVirtualInputReady {
-            _ = TT_CloseSoundInputDevice(instance)
-            teamTalkVirtualInputReady = false
+        if reinitOutput {
+            // Output bypass: the SDK output stays on the virtual device and is
+            // NEVER closed here — that close (TT_CloseSoundOutputDevice -> ACE
+            // recursive_mutex -> ResetAudioPlayers) is the call that intermittently
+            // deadlocks under HAL overload. Switching the output device is purely a
+            // rebind of OUR render engine to the newly-selected CoreAudio device:
+            // all our code, fast, and no SDK audio mutex involved. Master gain/mute
+            // persist in the engine across the switch.
+            if let device = resolveOutputEngineDeviceLocked() {
+                if outputRenderEngine.isRunning {
+                    AudioLogger.log("reinit: switching output engine to %@", device.name)
+                    try outputRenderEngine.switchDevice(device.deviceID)
+                    AudioLogger.log("reinit: output engine switched")
+                } else {
+                    AudioLogger.log("reinit: output engine idle; starts on next muxed block")
+                }
+            } else {
+                AudioLogger.log("reinit: no output device resolved for switch")
+            }
+            appliedOutputPreference = preferencesStore.preferences.preferredOutputDevice
         }
 
-        if outputAudioReady {
-            _ = TT_CloseSoundOutputDevice(instance)
-            outputAudioReady = false
-        }
-
-        try ensureDirectOutputAudioReadyLocked(instance: instance)
-
-        if wasVoiceTransmissionEnabled || wasInputAudioReady {
+        if reinitInput, wasVoiceTransmissionEnabled || wasInputAudioReady {
+            AudioLogger.log("reinit: restarting mic input")
             try ensureAdvancedMicrophoneInputReadyLocked(instance: instance)
+            AudioLogger.log("reinit: mic input restarted")
         }
 
-        if wasVoiceTransmissionEnabled {
+        if reinitInput, wasVoiceTransmissionEnabled {
             voiceTransmissionEnabled = true
         }
 
         captureAudioRoutingSnapshotLocked()
+        AudioLogger.log("reinitializeAudioDevicesLocked: done")
     }
 
     func makeAudioStatusText() -> String {
@@ -493,62 +557,6 @@ extension TeamTalkConnectionController {
         return status
     }
 
-    func loadSoundDevicesLocked(forceRefresh: Bool) -> [SoundDevice] {
-        if forceRefresh == false, cachedSoundDevices.isEmpty == false {
-            return cachedSoundDevices
-        }
-
-        var count: INT32 = 0
-        guard TT_GetSoundDevices(nil, &count) != 0, count > 0 else {
-            cachedSoundDevices = []
-            cachedAudioDeviceCatalog = .empty
-            return []
-        }
-
-        var devices = Array(repeating: SoundDevice(), count: Int(count))
-        guard TT_GetSoundDevices(&devices, &count) != 0 else {
-            cachedSoundDevices = []
-            cachedAudioDeviceCatalog = .empty
-            return []
-        }
-
-        cachedSoundDevices = Array(devices.prefix(Int(count)))
-        AudioLogger.log("loadSoundDevicesLocked: loaded %d devices", cachedSoundDevices.count)
-        return cachedSoundDevices
-    }
-
-    func availableAudioDevicesLocked(forceRefresh: Bool) -> AudioDeviceCatalog {
-        if forceRefresh == false, let cachedAudioDeviceCatalog {
-            return cachedAudioDeviceCatalog
-        }
-
-        let activeDevices = loadSoundDevicesLocked(forceRefresh: forceRefresh)
-            .filter { ttString(from: $0.szDeviceName).hasPrefix("CADefaultDeviceAggregate") == false }
-        let inputDevices = activeDevices
-            .filter { $0.nMaxInputChannels > 0 && $0.nDeviceID != TT_SOUNDDEVICE_ID_TEAMTALK_VIRTUAL }
-            .map(makeAudioDeviceOption(from:))
-            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
-        let outputDevices = activeDevices
-            .filter { $0.nMaxOutputChannels > 0 && $0.nDeviceID != TT_SOUNDDEVICE_ID_TEAMTALK_VIRTUAL }
-            .map(makeAudioDeviceOption(from:))
-            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
-
-        let catalog = AudioDeviceCatalog(inputDevices: inputDevices, outputDevices: outputDevices)
-        cachedAudioDeviceCatalog = catalog
-        return catalog
-    }
-
-    func makeAudioDeviceOption(from device: SoundDevice) -> AudioDeviceOption {
-        let persistentID = ttString(from: device.szDeviceID).isEmpty
-            ? "legacy:\(device.nDeviceID)"
-            : ttString(from: device.szDeviceID)
-        return AudioDeviceOption(
-            id: persistentID,
-            persistentID: persistentID,
-            displayName: ttString(from: device.szDeviceName)
-        )
-    }
-
     func ensureDirectOutputAudioReadyLocked(instance: UnsafeMutableRawPointer) throws {
         guard outputAudioReady == false else {
             return
@@ -562,15 +570,169 @@ extension TeamTalkConnectionController {
             return
         }
 
-        let outputDeviceID = try selectedOutputDeviceIDLocked()
-        AudioLogger.log("ensureDirectOutputAudioReady: opening output device ID=%d", outputDeviceID)
-        guard TT_InitSoundOutputDevice(instance, outputDeviceID) != 0 else {
-            AudioLogger.log("ensureDirectOutputAudioReady: FAILED to open output device")
+        // Output bypass: point the SDK at the virtual output device so it never
+        // owns a physical CoreAudio output device (whose close intermittently
+        // deadlocks). We receive each remote user's decoded PCM as per-user audio
+        // blocks and MIX them ourselves (the local user is never fed in, so you
+        // never hear yourself) through OutputAudioRenderEngine, which also lets us
+        // own per-person pan/volume/mute. The physical output device is chosen by
+        // the render engine (resolveOutputEngineDeviceLocked), not the SDK.
+        AudioLogger.log("ensureDirectOutputAudioReady: opening virtual output device (bypass)")
+        guard TT_InitSoundOutputDevice(instance, TT_SOUNDDEVICE_ID_TEAMTALK_VIRTUAL) != 0 else {
+            AudioLogger.log("ensureDirectOutputAudioReady: FAILED to open virtual output device")
             throw TeamTalkConnectionError.internalError(L10n.text("connectedServer.audio.error.outputStartFailed"))
         }
         outputAudioReady = true
-        applyOutputGainLocked(instance: instance, gainDB: preferencesStore.preferences.outputGainDB)
-        AudioLogger.log("ensureDirectOutputAudioReady: output ready")
+        appliedOutputPreference = preferencesStore.preferences.preferredOutputDevice
+        startOutputRenderEngineLocked()
+        // Enable per-user audio block events for whoever is already in our channel.
+        refreshPerUserAudioEventsLocked(instance: instance)
+        AudioLogger.log("ensureDirectOutputAudioReady: virtual output ready")
+    }
+
+    /// Resolve the CoreAudio output device the render engine should bind to,
+    /// honoring the user's explicit preference and falling back to the system
+    /// default output.
+    func resolveOutputEngineDeviceLocked() -> InputAudioDeviceResolver.OutputAudioDeviceInfo? {
+        let pref = preferencesStore.preferences.preferredOutputDevice
+        if pref.usesSystemDefault == false,
+           let info = InputAudioDeviceResolver.resolveOutputDevice(
+               persistentID: pref.persistentID,
+               displayName: pref.displayName
+           ) {
+            return info
+        }
+        let devices = InputAudioDeviceResolver.availableOutputDevices()
+        if let defaultUID = InputAudioDeviceResolver.defaultOutputDeviceUID(),
+           let match = devices.first(where: { $0.uid == defaultUID }) {
+            return match
+        }
+        return devices.first
+    }
+
+    /// Start the output render engine on the currently-selected output device.
+    func startOutputRenderEngineLocked() {
+        guard outputAudioReady, outputRenderEngine.isRunning == false else { return }
+        guard let device = resolveOutputEngineDeviceLocked() else {
+            AudioLogger.log("outputRenderEngine: no output device available to start")
+            return
+        }
+        outputRenderEngine.setMasterGainDB(preferencesStore.preferences.outputGainDB)
+        outputRenderEngine.setMuted(masterMuted)
+        do {
+            try outputRenderEngine.start(deviceID: device.deviceID)
+            AudioLogger.log("outputRenderEngine: started on %@", device.name)
+        } catch {
+            AudioLogger.log("outputRenderEngine: start failed — %@", error.localizedDescription)
+        }
+    }
+
+    /// Separate mixer key for a user's media-file stream (kept distinct from their
+    /// voice stream).
+    func outputMediaSourceKey(_ userID: Int32) -> Int32 { userID | 0x4000_0000 }
+
+    /// Reserved mixer key for the local "hear myself" monitor (negative, so it
+    /// never collides with real user IDs or media keys, both positive).
+    var localMonitorEngineKey: Int32 { -1 }
+
+    /// Reconcile per-user audio block events with the users currently in our
+    /// channel: enable for newly-present remote users, disable + drop for users
+    /// who left. The local user is never enabled, so our own voice is never mixed.
+    func refreshPerUserAudioEventsLocked(instance: UnsafeMutableRawPointer) {
+        perUserAudioNeedsRefresh = false
+        guard outputAudioReady else { return }
+        let myUserID = TT_GetMyUserID(instance)
+        let myChannel = TT_GetMyChannelID(instance)
+        // Per-user audio block events want a SINGLE stream type (unlike the muxed
+        // user, which accepts an OR'd mask), so enable VOICE and MEDIA separately.
+        let voice = UInt32(STREAMTYPE_VOICE.rawValue)
+        let media = UInt32(STREAMTYPE_MEDIAFILE_AUDIO.rawValue)
+
+        var desired = Set<Int32>()
+        if myChannel > 0 {
+            for user in channelUsersLocked(instance: instance, channelID: myChannel)
+            where user.nUserID != myUserID && user.nUserID > 0 {
+                desired.insert(user.nUserID)
+            }
+        }
+
+        let toEnable = desired.subtracting(perUserAudioEnabled)
+        let toDisable = perUserAudioEnabled.subtracting(desired)
+        for userID in toEnable {
+            TT_EnableAudioBlockEvent(instance, userID, voice, 1)
+            TT_EnableAudioBlockEvent(instance, userID, media, 1)
+        }
+        for userID in toDisable {
+            TT_EnableAudioBlockEvent(instance, userID, voice, 0)
+            TT_EnableAudioBlockEvent(instance, userID, media, 0)
+            outputRenderEngine.removeUser(userID)
+            outputRenderEngine.removeUser(outputMediaSourceKey(userID))
+        }
+        perUserAudioEnabled = desired
+    }
+
+    func channelUsersLocked(instance: UnsafeMutableRawPointer, channelID: Int32) -> [User] {
+        var count: INT32 = 0
+        guard TT_GetChannelUsers(instance, channelID, nil, &count) != 0, count > 0 else { return [] }
+        var users = Array(repeating: User(), count: Int(count))
+        guard TT_GetChannelUsers(instance, channelID, &users, &count) != 0 else { return [] }
+        return Array(users.prefix(Int(count)))
+    }
+
+    /// Dispatch a CLIENTEVENT_USER_AUDIOBLOCK. A remote user's voice/media goes to
+    /// the mixer for playback; the muxed stream (only enabled as the pre-14.2 AEC
+    /// fallback) feeds the echo canceller's far-end reference.
+    func handleAudioBlockLocked(instance: UnsafeMutableRawPointer, source: Int32) {
+        if source == TT_MUXED_USERID {
+            guard let block = TT_AcquireUserAudioBlock(instance, UInt32(STREAMTYPE_VOICE.rawValue), TT_MUXED_USERID) else { return }
+            if speakerTapCaptureStorage == nil,
+               let aec = advancedMicrophoneEngine.echoCanceller,
+               let rawAudio = block.pointee.lpRawAudio {
+                let int16Ptr = rawAudio.assumingMemoryBound(to: Int16.self)
+                aec.feedReference(int16Ptr, count: Int(block.pointee.nSamples), channels: Int(block.pointee.nChannels), sampleRate: Int(block.pointee.nSampleRate))
+            }
+            TT_ReleaseUserAudioBlock(instance, block)
+            return
+        }
+
+        let myUserID = TT_GetMyUserID(instance)
+        guard source > 0, source != myUserID else { return }
+        enqueueUserAudioBlockLocked(instance: instance, userID: source, streamType: STREAMTYPE_VOICE, engineKey: source)
+        enqueueUserAudioBlockLocked(instance: instance, userID: source, streamType: STREAMTYPE_MEDIAFILE_AUDIO, engineKey: outputMediaSourceKey(source))
+    }
+
+    private func enqueueUserAudioBlockLocked(instance: UnsafeMutableRawPointer, userID: Int32, streamType: StreamType, engineKey: Int32) {
+        guard let block = TT_AcquireUserAudioBlock(instance, UInt32(streamType.rawValue), userID) else { return }
+        defer { TT_ReleaseUserAudioBlock(instance, block) }
+        let frames = Int(block.pointee.nSamples)
+        let channels = Int(block.pointee.nChannels)
+        let sampleRate = Int(block.pointee.nSampleRate)
+        guard frames > 0, channels > 0, sampleRate > 0, let rawAudio = block.pointee.lpRawAudio else { return }
+        // Copy the SDK PCM out before the block is released — the engine consumes it
+        // asynchronously on its own queue.
+        let samplePtr = rawAudio.assumingMemoryBound(to: Int16.self)
+        let pcm = Array(UnsafeBufferPointer(start: samplePtr, count: frames * channels))
+        outputRenderEngine.enqueueUser(
+            engineKey,
+            pcm: pcm,
+            frames: frames, channels: channels, sampleRate: Double(sampleRate)
+        )
+    }
+
+    /// Tear down the output render path (engine + all per-user / muxed events).
+    func teardownOutputRenderLocked(instance: UnsafeMutableRawPointer?) {
+        outputRenderEngine.stop()
+        if let instance {
+            let voice = UInt32(STREAMTYPE_VOICE.rawValue)
+            let media = UInt32(STREAMTYPE_MEDIAFILE_AUDIO.rawValue)
+            for userID in perUserAudioEnabled {
+                TT_EnableAudioBlockEvent(instance, userID, voice, 0)
+                TT_EnableAudioBlockEvent(instance, userID, media, 0)
+            }
+            TT_EnableAudioBlockEvent(instance, TT_MUXED_USERID, voice, 0)
+        }
+        perUserAudioEnabled.removeAll()
+        perUserAudioNeedsRefresh = false
     }
 
     func stopAdvancedMicrophoneInputLocked(instance: UnsafeMutableRawPointer, reason: String) {
@@ -580,8 +742,11 @@ extension TeamTalkConnectionController {
             (speakerTapCaptureStorage as? SpeakerTapCapture)?.stop()
         }
         speakerTapCaptureStorage = nil
+        // Disable the muxed AEC-reference event (playback uses per-user events,
+        // managed separately by refreshPerUserAudioEventsLocked).
         TT_EnableAudioBlockEvent(instance, TT_MUXED_USERID, UInt32(STREAMTYPE_VOICE.rawValue), 0)
         advancedMicrophoneEngine.stop()
+        outputRenderEngine.removeUser(localMonitorEngineKey)
         _ = TT_InsertAudioBlock(instance, nil)
         inputAudioReady = false
         advancedMicrophoneTargetFormat = nil
@@ -681,6 +846,22 @@ extension TeamTalkConnectionController {
             if accepted == false {
                 AudioLogger.log("TT_InsertAudioBlock: queue full, audio block dropped")
             }
+
+            // Local monitor: feed the same processed mic audio we're transmitting
+            // straight into the output mixer — local, no SDK round-trip. Drives both
+            // "hear myself" and the connected-mode Audio-preferences mic preview
+            // (one shared source key, so enabling both never doubles the audio).
+            if hearMyselfEnabled || previewMonitorEnabled {
+                let pcm = Array(UnsafeBufferPointer(start: baseAddress,
+                                                    count: Int(chunk.sampleCount) * Int(chunk.channels)))
+                outputRenderEngine.enqueueUser(
+                    localMonitorEngineKey,
+                    pcm: pcm,
+                    frames: Int(chunk.sampleCount),
+                    channels: Int(chunk.channels),
+                    sampleRate: Double(chunk.sampleRate)
+                )
+            }
         }
     }
 
@@ -762,25 +943,9 @@ extension TeamTalkConnectionController {
         }
     }
 
-    func selectedOutputDeviceIDLocked() throws -> INT32 {
-        try selectedDeviceIDLocked(
-            preference: preferencesStore.preferences.preferredOutputDevice,
-            availableDevices: availableAudioDevicesLocked(forceRefresh: false).outputDevices,
-            direction: .output
-        )
-    }
-
-    func selectedInputDeviceIDLocked() throws -> INT32 {
-        try selectedDeviceIDLocked(
-            preference: preferencesStore.preferences.preferredInputDevice,
-            availableDevices: availableAudioDevicesLocked(forceRefresh: false).inputDevices,
-            direction: .input
-        )
-    }
-
     func applyOutputGainLocked(instance: UnsafeMutableRawPointer, gainDB: Double) {
-        let volume = Self.teamTalkVolume(for: gainDB)
-        _ = TT_SetSoundOutputVolume(instance, volume)
+        // Master output gain is applied by our render engine on the muxed stream.
+        outputRenderEngine.setMasterGainDB(gainDB)
     }
 
     // MARK: - Jitter Control
@@ -800,17 +965,32 @@ extension TeamTalkConnectionController {
     func toggleHearMyself(completion: @escaping @MainActor (Bool) -> Void) {
         queue.async { [weak self] in
             guard let self, let instance = self.instance else { return }
-            let myUserID = TT_GetMyUserID(instance)
-            guard myUserID > 0 else { return }
+            guard TT_GetMyUserID(instance) > 0 else { return }
             let newEnabled = !self.hearMyselfEnabled
-            let sub = Subscriptions(SUBSCRIBE_VOICE.rawValue)
-            if newEnabled {
-                _ = TT_DoSubscribe(instance, myUserID, sub)
-            } else {
-                _ = TT_DoUnsubscribe(instance, myUserID, sub)
-            }
             self.hearMyselfEnabled = newEnabled
+            // LOCAL monitor — no SDK round-trip. When on, the mic-chunk path feeds
+            // your own processed audio straight into the output mixer (see
+            // insertAdvancedMicrophoneAudioChunkLocked), so you hear yourself with
+            // only local buffering latency instead of mic→server→back. When off,
+            // drop the monitor source.
+            if newEnabled == false && self.previewMonitorEnabled == false {
+                self.outputRenderEngine.removeUser(self.localMonitorEngineKey)
+            }
             DispatchQueue.main.async { completion(newEnabled) }
+        }
+    }
+
+    /// Connected-mode mic preview: monitor the live mic through the output engine
+    /// (the input device is already owned by the live capture, so a second capture
+    /// can't open). Shares the local-monitor source with hearMyself. Produces audio
+    /// only while the mic is actually capturing/transmitting.
+    func setPreviewMonitor(_ enabled: Bool) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.previewMonitorEnabled = enabled
+            if enabled == false && self.hearMyselfEnabled == false {
+                self.outputRenderEngine.removeUser(self.localMonitorEngineKey)
+            }
         }
     }
 
@@ -972,52 +1152,15 @@ extension TeamTalkConnectionController {
 
     func toggleMasterMute(completion: @escaping @MainActor (Bool) -> Void) {
         queue.async { [weak self] in
-            guard let self, let instance = self.instance else { return }
+            guard let self, self.instance != nil else { return }
             let newMuted = !self.masterMuted
-            _ = TT_SetSoundOutputMute(instance, newMuted ? 1 : 0)
+            self.outputRenderEngine.setMuted(newMuted)
             self.masterMuted = newMuted
             SoundPlayer.shared.play(newMuted ? .muteAll : .unmuteAll)
             DispatchQueue.main.async {
                 completion(newMuted)
             }
         }
-    }
-
-    func selectedDeviceIDLocked(
-        preference: AudioDevicePreference,
-        availableDevices: [AudioDeviceOption],
-        direction: AudioDirection
-    ) throws -> INT32 {
-        var defaultInputDeviceID: INT32 = 0
-        var defaultOutputDeviceID: INT32 = 0
-        guard TT_GetDefaultSoundDevices(&defaultInputDeviceID, &defaultOutputDeviceID) != 0 else {
-            throw TeamTalkConnectionError.internalError(L10n.text("connectedServer.audio.error.defaultDevicesUnavailable"))
-        }
-
-        guard let persistentID = preference.persistentID, persistentID.isEmpty == false else {
-            return direction == .input ? defaultInputDeviceID : defaultOutputDeviceID
-        }
-
-        guard availableDevices.contains(where: { $0.persistentID == persistentID }) else {
-            return direction == .input ? defaultInputDeviceID : defaultOutputDeviceID
-        }
-
-        for device in loadSoundDevicesLocked(forceRefresh: false) {
-            let candidatePersistentID = ttString(from: device.szDeviceID).isEmpty
-                ? "legacy:\(device.nDeviceID)"
-                : ttString(from: device.szDeviceID)
-            guard candidatePersistentID == persistentID else {
-                continue
-            }
-            if direction == .input, device.nMaxInputChannels > 0 {
-                return device.nDeviceID
-            }
-            if direction == .output, device.nMaxOutputChannels > 0 {
-                return device.nDeviceID
-            }
-        }
-
-        return direction == .input ? defaultInputDeviceID : defaultOutputDeviceID
     }
 
     nonisolated static func teamTalkVolume(for gainDB: Double) -> INT32 {
@@ -1030,35 +1173,28 @@ extension TeamTalkConnectionController {
         return INT32(clamped)
     }
 
+    // Percent <-> SDK volume uses a GEOMETRIC (perceptually-uniform / dB-linear) curve:
+    // 50% = SOUND_VOLUME_DEFAULT (unity), 100% = SOUND_VOLUME_MAX, 0% = silence. Each
+    // percent is a constant ~0.6 dB step, so the slider sounds even across its range. A
+    // plain linear-gain mapping made the top half brutal — at SOUND_VOLUME_MAX=32000
+    // (32x), 50->51% jumped 1x->1.6x (~+4 dB) while 99->100% barely moved.
     nonisolated static func userVolumeFromPercent(_ percent: Double) -> INT32 {
-        let clampedPercent = min(max(percent.rounded(), 0), 100)
-        let minVolume = Double(SOUND_VOLUME_MIN.rawValue)
+        let pct = min(max(percent, 0), 100)
+        if pct <= 0 { return INT32(SOUND_VOLUME_MIN.rawValue) }
         let defaultVolume = Double(SOUND_VOLUME_DEFAULT.rawValue)
         let maxVolume = Double(SOUND_VOLUME_MAX.rawValue)
-        let raw: Double
-        if clampedPercent <= 50 {
-            raw = minVolume + (defaultVolume - minVolume) * (clampedPercent / 50)
-        } else {
-            raw = defaultVolume + (maxVolume - defaultVolume) * ((clampedPercent - 50) / 50)
-        }
-        let clamped = min(max(raw.rounded(), Double(SOUND_VOLUME_MIN.rawValue)), Double(SOUND_VOLUME_MAX.rawValue))
-        return INT32(clamped)
+        let ratio = pow(maxVolume / defaultVolume, (pct - 50) / 50)
+        let raw = (defaultVolume * ratio).rounded()
+        return INT32(min(max(raw, 1), maxVolume))
     }
 
     nonisolated static func percentFromUserVolume(_ volume: INT32) -> Int {
-        let v = min(max(Double(volume), Double(SOUND_VOLUME_MIN.rawValue)), Double(SOUND_VOLUME_MAX.rawValue))
-        let minVolume = Double(SOUND_VOLUME_MIN.rawValue)
+        let v = Double(volume)
+        if v <= 0 { return 0 }
         let defaultVolume = Double(SOUND_VOLUME_DEFAULT.rawValue)
         let maxVolume = Double(SOUND_VOLUME_MAX.rawValue)
-        let percent: Double
-        if v <= defaultVolume {
-            let span = max(defaultVolume - minVolume, 1)
-            percent = (v - minVolume) / span * 50
-        } else {
-            let span = max(maxVolume - defaultVolume, 1)
-            percent = 50 + ((v - defaultVolume) / span * 50)
-        }
-        return Int(min(max(percent.rounded(), 0), 100))
+        let pct = 50 + 50 * (log(v / defaultVolume) / log(maxVolume / defaultVolume))
+        return Int(min(max(pct.rounded(), 0), 100))
     }
 
     nonisolated static func formatGainDB(_ value: Double) -> String {
@@ -1082,7 +1218,6 @@ extension TeamTalkConnectionController {
         }
 
         let previous = lastAudioRoutingSnapshot
-        cachedSoundDevices = []
         cachedAudioDeviceCatalog = nil
         let current = makeAudioRoutingSnapshotLocked()
 
@@ -1132,12 +1267,21 @@ extension TeamTalkConnectionController {
         )
         let outputPreference = preferences.preferredOutputDevice
         let outputPersistentID = outputPreference.persistentID
-        let catalog = availableAudioDevicesLocked(forceRefresh: true)
+        // Read ONLY the already-cached SDK device catalog — never trigger a load
+        // here. On a large rig the SDK's TT_GetSoundDevices probe takes ~12 s; doing
+        // it on the connect path (this snapshot runs during connect) is what made
+        // connecting slow. If the catalog hasn't been loaded yet, assume the chosen
+        // output is present — a later snapshot corrects it once the cache populates
+        // (the device picker, or processAudioHardwareChangeLocked on a real change).
         let outputInCatalog: Bool
-        if let outputPersistentID, outputPersistentID.isEmpty == false {
-            outputInCatalog = catalog.outputDevices.contains { $0.persistentID == outputPersistentID }
+        if let catalog = cachedAudioDeviceCatalog {
+            if let outputPersistentID, outputPersistentID.isEmpty == false {
+                outputInCatalog = catalog.outputDevices.contains { $0.persistentID == outputPersistentID }
+            } else {
+                outputInCatalog = catalog.outputDevices.isEmpty == false
+            }
         } else {
-            outputInCatalog = catalog.outputDevices.isEmpty == false
+            outputInCatalog = true
         }
 
         return AudioRoutingSnapshot(

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -168,8 +168,8 @@ extension TeamTalkConnectionController {
             let prefersOutputDevice = !self.preferencesStore.preferences.preferredOutputDevice.usesNoOutput
             if (hadOutput || prefersOutputDevice), let instance = self.instance {
                 do {
-                    // Reopens the virtual output + muxed event; the render engine
-                    // restarts on the next muxed block (gain/mute reapplied inside).
+                    // Reopens the virtual output + muxed event and starts the render
+                    // engine directly (gain/mute reapplied inside).
                     try self.ensureDirectOutputAudioReadyLocked(instance: instance)
                 } catch {
                     AudioLogger.log("restartSoundSystem: output re-open failed — %@", error.localizedDescription)

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Connection.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Connection.swift
@@ -776,9 +776,9 @@ extension TeamTalkConnectionController {
                             outputAudioReady = false
                         }
                         do {
-                            // Reopens the virtual output + muxed event; the render
-                            // engine restarts on the next muxed block (mute/gain
-                            // are reapplied from prefs inside the ensure path).
+                            // Reopens the virtual output + muxed event and starts the
+                            // render engine directly (mute/gain reapplied from prefs
+                            // inside the ensure path).
                             try ensureDirectOutputAudioReadyLocked(instance: instance)
                         } catch {
                             AudioLogger.log("INTERNAL_ERROR: failed to reopen output — %@", error.localizedDescription)
@@ -862,6 +862,16 @@ extension TeamTalkConnectionController {
                         }
                         if let storedBalance = userVolumeStore.stereoBalance(forUsername: joinedUsername) {
                             _ = TT_SetUserStereo(instance, message.user.nUserID, STREAMTYPE_VOICE, storedBalance.left ? 1 : 0, storedBalance.right ? 1 : 0)
+                        }
+                        // Continuous mixer pan lives in our own render engine (not the SDK),
+                        // so push it here too — otherwise the strip shows the saved pan while
+                        // the user plays centered until the slider is touched. muted:false is
+                        // the engine default; an active SOLO is re-applied right after via the
+                        // coordinator's reapplySolo() on the next session update.
+                        if let storedPan = userVolumeStore.pan(forUsername: joinedUsername) {
+                            let panSettings = OutputUserMixSettings(volume: 1, pan: storedPan, muted: false)
+                            outputRenderEngine.setUserSettings(panSettings, for: message.user.nUserID)
+                            outputRenderEngine.setUserSettings(panSettings, for: outputMediaSourceKey(message.user.nUserID))
                         }
                         applyJitterControlLocked(instance: instance, userID: message.user.nUserID)
                     case CLIENTEVENT_CMD_USER_LEFT:
@@ -984,6 +994,12 @@ extension TeamTalkConnectionController {
         lastSnapshotPublishAt = 0
         outputAudioReady = false
         inputAudioReady = false
+        // Reset the device-preference dedup state too: the sound devices are closed
+        // above, so on the next connect (which may reuse this warm instance)
+        // applyAudioPreferences must re-initialize them. Leaving these set would let
+        // the `applied == new` dedup guard silently skip re-applying the device.
+        appliedInputPreference = nil
+        appliedOutputPreference = nil
         voiceTransmissionEnabled = false
         masterMuted = false
         hearMyselfEnabled = false
@@ -1147,6 +1163,16 @@ extension TeamTalkConnectionController {
                         }
                         if let storedBalance = userVolumeStore.stereoBalance(forUsername: joinedUsername) {
                             _ = TT_SetUserStereo(instance, message.user.nUserID, STREAMTYPE_VOICE, storedBalance.left ? 1 : 0, storedBalance.right ? 1 : 0)
+                        }
+                        // Continuous mixer pan lives in our own render engine (not the SDK),
+                        // so push it here too — otherwise the strip shows the saved pan while
+                        // the user plays centered until the slider is touched. muted:false is
+                        // the engine default; an active SOLO is re-applied right after via the
+                        // coordinator's reapplySolo() on the next session update.
+                        if let storedPan = userVolumeStore.pan(forUsername: joinedUsername) {
+                            let panSettings = OutputUserMixSettings(volume: 1, pan: storedPan, muted: false)
+                            outputRenderEngine.setUserSettings(panSettings, for: message.user.nUserID)
+                            outputRenderEngine.setUserSettings(panSettings, for: outputMediaSourceKey(message.user.nUserID))
                         }
                         applyJitterControlLocked(instance: instance, userID: message.user.nUserID)
                     case CLIENTEVENT_CMD_USER_UPDATE:

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Connection.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Connection.swift
@@ -70,6 +70,8 @@ extension TeamTalkConnectionController {
             self.appendDisconnectedHistoryLocked()
             self.resetLocked()
             self.publishDisconnected(message: nil)
+            // No prewarm needed here — destroyLocked kept the warm instance in
+            // `reusableInstance`, so the next connect reuses it directly.
         }
     }
 
@@ -83,10 +85,63 @@ extension TeamTalkConnectionController {
     // MARK: - Instance creation
 
     func createInstanceLocked() throws -> UnsafeMutableRawPointer {
+        // Reuse a warm instance kept from a previous connection — it's already past
+        // the SDK's ~8 s device enumeration, so this connect is ~1 s instead of cold.
+        if let reusable = reusableInstance {
+            reusableInstance = nil
+            return reusable
+        }
+        // Reuse a background-prewarmed instance if one is ready or in flight — this
+        // is what keeps the ~12 s TT_InitTeamTalkPoll device-enumeration off the
+        // connect path. If a prewarm is in flight, wait for it (the probe queue
+        // signals the semaphore directly, so blocking `queue` here can't deadlock).
+        if prewarmInFlight {
+            prewarmReady.wait()
+            prewarmInFlight = false
+            prewarmBoxLock.lock()
+            let prewarmed = prewarmBoxedInstance
+            prewarmBoxedInstance = nil
+            prewarmBoxLock.unlock()
+            if let prewarmed {
+                return prewarmed
+            }
+        }
         guard let instance = TT_InitTeamTalkPoll() else {
             throw TeamTalkConnectionError.sdkUnavailable
         }
         return instance
+    }
+
+    /// Create the next TeamTalk instance ahead of time on the probe queue so the
+    /// SDK's ~12 s device-enumeration init never lands on the connect path. Safe to
+    /// call repeatedly; no-ops while connected, already prewarmed, or in flight.
+    func prewarmConnection() {
+        queue.async { [weak self] in
+            guard let self,
+                  self.instance == nil,
+                  self.reusableInstance == nil,
+                  self.prewarmInFlight == false else { return }
+            // Already have a boxed instance from a previous prewarm? Then we're ready.
+            self.prewarmBoxLock.lock()
+            let alreadyBoxed = self.prewarmBoxedInstance != nil
+            self.prewarmBoxLock.unlock()
+            if alreadyBoxed { return }
+
+            self.prewarmInFlight = true
+            AudioLogger.log("prewarm: creating instance in background")
+            self.soundDeviceProbeQueue.async { [weak self] in
+                let inst = TT_InitTeamTalkPoll()
+                guard let self else {
+                    if let inst { TT_CloseTeamTalk(inst) }
+                    return
+                }
+                self.prewarmBoxLock.lock()
+                self.prewarmBoxedInstance = inst
+                self.prewarmBoxLock.unlock()
+                self.prewarmReady.signal()
+                AudioLogger.log("prewarm: instance ready")
+            }
+        }
     }
 
     // MARK: - History suppression
@@ -454,8 +509,14 @@ extension TeamTalkConnectionController {
     func startPollingLocked() {
         stopPollingLocked()
 
+        // Poll at 10 ms (was 100 ms). The SDK delivers muxed playback audio blocks
+        // (~one per codec tx-interval, e.g. 20 ms) only through this message queue;
+        // a 100 ms poll drained ~5 blocks at once then starved the output render
+        // engine for the rest of the cycle, causing underrun crackle. A 10 ms poll
+        // delivers blocks smoothly as they're produced so a small jitter buffer
+        // suffices (no added latency). Drains are cheap no-ops when the queue is empty.
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + .milliseconds(100), repeating: .milliseconds(100))
+        timer.schedule(deadline: .now() + .milliseconds(20), repeating: .milliseconds(20), leeway: .milliseconds(4))
         timer.setEventHandler { [weak self] in
             self?.drainMessagesLocked()
         }
@@ -479,6 +540,13 @@ extension TeamTalkConnectionController {
         var waitMSec: INT32 = 0
         var publishInvalidation: SessionPublishInvalidation = []
         defer {
+            // Reconcile per-user audio events when channel membership changed, then
+            // top up the output mixer's ring for this tick.
+            if outputAudioReady, perUserAudioNeedsRefresh {
+                // Audio mixing now runs on the engine's own timer (engineQueue); the
+                // message loop only reconciles which per-user events are enabled.
+                refreshPerUserAudioEventsLocked(instance: instance)
+            }
             // Poll active transfers for current progress (SDK only fires CLIENTEVENT_FILETRANSFER
             // at start/end, not during the transfer — we must poll TT_GetFileTransferInfo)
             if !activeTransferProgress.isEmpty, let _ = connectedRecord {
@@ -507,11 +575,24 @@ extension TeamTalkConnectionController {
                     publishInvalidation = .all
                 }
             }
-            if publishInvalidation.contains(.activeTransfers),
-               publishInvalidation.intersection([.rootTree, .chat, .history, .privateConversations, .channelFiles, .audio, .identity, .permissions]).isEmpty {
+            // Coalesce the expensive full-session publish. The message poll is fast
+            // (20 ms) so per-user audio blocks arrive smoothly, but rebuilding the
+            // whole channel/user tree every tick during the connect flood made
+            // connecting slow. Accumulate invalidations and rebuild at most ~every
+            // 80 ms (the old ~100 ms cadence) — pending changes still flush within a
+            // few ticks since the timer fires regardless of message traffic. The
+            // lightweight transfer-progress publish stays immediate.
+            let heavyBits: SessionPublishInvalidation = [.rootTree, .chat, .history, .privateConversations, .channelFiles, .audio, .identity, .permissions]
+            pendingPublishInvalidation.formUnion(publishInvalidation)
+            if pendingPublishInvalidation.contains(.activeTransfers),
+               pendingPublishInvalidation.intersection(heavyBits).isEmpty {
                 publishActiveTransfersLocked(currentChannelID: TT_GetMyChannelID(instance))
-            } else if !publishInvalidation.isEmpty, let connectedRecord {
-                publishSessionLocked(instance: instance, record: connectedRecord, invalidation: publishInvalidation)
+                pendingPublishInvalidation = []
+            } else if !pendingPublishInvalidation.isEmpty, let connectedRecord,
+                      now - lastSnapshotPublishAt >= 0.08 {
+                publishSessionLocked(instance: instance, record: connectedRecord, invalidation: pendingPublishInvalidation)
+                pendingPublishInvalidation = []
+                lastSnapshotPublishAt = now
             }
         }
 
@@ -551,18 +632,8 @@ extension TeamTalkConnectionController {
             case CLIENTEVENT_AUDIOINPUT:
                 break
             case CLIENTEVENT_USER_AUDIOBLOCK:
-                // Feed muxed audio to echo canceller as far-end reference (fallback when speaker tap is unavailable).
-                if speakerTapCaptureStorage == nil,
-                   let aec = advancedMicrophoneEngine.echoCanceller,
-                   message.nSource == TT_MUXED_USERID {
-                    if let block = TT_AcquireUserAudioBlock(instance, UInt32(STREAMTYPE_VOICE.rawValue), TT_MUXED_USERID) {
-                        if let rawAudio = block.pointee.lpRawAudio {
-                            let int16Ptr = rawAudio.assumingMemoryBound(to: Int16.self)
-                            aec.feedReference(int16Ptr, count: Int(block.pointee.nSamples), channels: Int(block.pointee.nChannels), sampleRate: Int(block.pointee.nSampleRate))
-                        }
-                        TT_ReleaseUserAudioBlock(instance, block)
-                    }
-                }
+                // Per-user remote audio → our mixer (playback); muxed → AEC reference.
+                handleAudioBlockLocked(instance: instance, source: message.nSource)
             case CLIENTEVENT_CMD_MYSELF_KICKED:
                 if connectedRecord != nil {
                     appendKickHistoryLocked(message, instance: instance)
@@ -700,14 +771,15 @@ extension TeamTalkConnectionController {
                         // Sound output device failed (e.g. unplugged). Reopen it.
                         AudioLogger.log("INTERNAL_ERROR: output device failure, reopening")
                         if outputAudioReady {
+                            teardownOutputRenderLocked(instance: instance)
                             _ = TT_CloseSoundOutputDevice(instance)
                             outputAudioReady = false
                         }
                         do {
+                            // Reopens the virtual output + muxed event; the render
+                            // engine restarts on the next muxed block (mute/gain
+                            // are reapplied from prefs inside the ensure path).
                             try ensureDirectOutputAudioReadyLocked(instance: instance)
-                            if masterMuted {
-                                _ = TT_SetSoundOutputMute(instance, 1)
-                            }
                         } catch {
                             AudioLogger.log("INTERNAL_ERROR: failed to reopen output — %@", error.localizedDescription)
                         }
@@ -728,6 +800,8 @@ extension TeamTalkConnectionController {
                  CLIENTEVENT_CMD_USER_LEFT:
                 if connectedRecord != nil {
                     let currentUserID = TT_GetMyUserID(instance)
+                    // Channel membership may have changed → reconcile per-user audio.
+                    perUserAudioNeedsRefresh = true
                     switch message.nClientEvent {
                     case CLIENTEVENT_CMD_USER_LOGGEDIN:
                         if isSuppressingLoginHistoryLocked == false {
@@ -843,10 +917,15 @@ extension TeamTalkConnectionController {
                 teamTalkVirtualInputReady = false
             }
             if outputAudioReady {
+                teardownOutputRenderLocked(instance: instance)
                 _ = TT_CloseSoundOutputDevice(instance)
             }
             TT_Disconnect(instance)
-            TT_CloseTeamTalk(instance)
+            // Keep the instance alive and WARM for reuse instead of closing it.
+            // TT_CloseTeamTalk would force the next connect to recreate the instance
+            // and re-run the SDK's ~8 s device enumeration; reuse keeps reconnects
+            // ~1 s. (Also avoids the documented TT_CloseTeamTalk-at-exit crash.)
+            reusableInstance = instance
         }
 
         mediaStreamingSecurityScopedURL?.stopAccessingSecurityScopedResource()
@@ -898,11 +977,17 @@ extension TeamTalkConnectionController {
         selectedPrivateConversationUserID = nil
         visiblePrivateConversationUserID = nil
         isPrivateMessagesWindowVisible = false
+        outputRenderEngine.stop()
+        perUserAudioEnabled.removeAll()
+        perUserAudioNeedsRefresh = false
+        pendingPublishInvalidation = []
+        lastSnapshotPublishAt = 0
         outputAudioReady = false
         inputAudioReady = false
         voiceTransmissionEnabled = false
         masterMuted = false
         hearMyselfEnabled = false
+        previewMonitorEnabled = false
         teamTalkVirtualInputReady = false
         advancedMicrophoneTargetFormat = nil
         isAutoAwayActive = false
@@ -1009,6 +1094,8 @@ extension TeamTalkConnectionController {
                  CLIENTEVENT_CMD_USER_LEFT:
                 if let connectedRecord {
                     let currentUserID = TT_GetMyUserID(instance)
+                    // Channel membership may have changed → reconcile per-user audio.
+                    perUserAudioNeedsRefresh = true
                     switch message.nClientEvent {
                     case CLIENTEVENT_CMD_USER_LOGGEDIN:
                         if isSuppressingLoginHistoryLocked == false {

--- a/App/ttaccessible/Services/TeamTalkConnectionController.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController.swift
@@ -72,7 +72,7 @@ final class TeamTalkConnectionController {
 
     let queueKey = DispatchSpecificKey<Void>()
     let queue = DispatchQueue(label: "com.math65.ttaccessible.teamtalk")
-    let clientName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "TTAccessible"
+    let clientName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "tt-Accessible"
     let preferencesStore: AppPreferencesStore
     let userVolumeStore = UserVolumeStore()
     let lastChannelStore = LastChannelStore()
@@ -335,7 +335,7 @@ final class TeamTalkConnectionController {
             return preferredNickname
         }
 
-        return "TTAccessible"
+        return "tt-Accessible"
     }
 
     func clientVersion(for user: User) -> String {

--- a/App/ttaccessible/Services/TeamTalkConnectionController.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController.swift
@@ -72,7 +72,30 @@ final class TeamTalkConnectionController {
 
     let queueKey = DispatchSpecificKey<Void>()
     let queue = DispatchQueue(label: "com.math65.ttaccessible.teamtalk")
-    let clientName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "tt-Accessible"
+    /// Dedicated queue for the SDK's TT_GetSoundDevices / TT_InitTeamTalkPoll probes,
+    /// kept OFF the main `queue` so they never block connecting or starve the realtime
+    /// audio mixer pump. QoS is `.userInitiated` (not `.utility`): the connect path runs
+    /// at user-initiated priority and waits on the prewarm done here, so a lower QoS
+    /// caused a priority inversion (Thread Performance Checker) that slowed connecting.
+    let soundDeviceProbeQueue = DispatchQueue(label: "com.math65.ttaccessible.sounddevices", qos: .userInitiated)
+    /// Connection-instance prewarm. `TT_InitTeamTalkPoll` triggers the SDK sound
+    /// system init, which enumerates every CoreAudio device (~12 s on a large rig).
+    /// The app creates a fresh instance per connect, so that 12 s landed on EVERY
+    /// connect. We instead create the next instance ahead of time on the probe
+    /// queue (at launch and after disconnect) so connect reuses a ready one.
+    var prewarmInFlight = false                              // `queue`-only
+    let prewarmReady = DispatchSemaphore(value: 0)
+    let prewarmBoxLock = NSLock()
+    var prewarmBoxedInstance: UnsafeMutableRawPointer?       // probe queue → `queue`, lock + semaphore guarded
+    /// A disconnected-but-still-alive TeamTalk instance kept WARM for reuse. The
+    /// SDK re-runs its ~8 s device enumeration every time a fresh instance is
+    /// created, so closing the instance on disconnect made every reconnect cold
+    /// (~8 s). Keeping it (TT_Disconnect, not TT_CloseTeamTalk) makes reconnects
+    /// reuse the warm instance and connect in ~1 s. `queue`-only.
+    var reusableInstance: UnsafeMutableRawPointer?
+    let clientName = (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+        ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String)
+        ?? "tt-Accessible"
     let preferencesStore: AppPreferencesStore
     let userVolumeStore = UserVolumeStore()
     let lastChannelStore = LastChannelStore()
@@ -106,12 +129,22 @@ final class TeamTalkConnectionController {
     var isPrivateMessagesWindowVisible = false
     var outputAudioReady = false
     var inputAudioReady = false
+    // The input/output device preferences currently open in the SDK, so a
+    // preference change can reinitialize only the device that actually changed
+    // (avoids needlessly closing the output — and its intermittent SDK deadlock —
+    // when only the input changed, and vice versa).
+    var appliedInputPreference: AudioDevicePreference?
+    var appliedOutputPreference: AudioDevicePreference?
     var voiceTransmissionEnabled = false
     var pushToTalkPressed = false
     var pushToTalkShortcutResolver: (() -> Bool)?
     var lastAudioWarningMessage: String?
     var masterMuted = false
     var hearMyselfEnabled = false
+    // When connected, the Audio-preferences mic preview can't open a second capture
+    // on the input device (the live mic engine owns it), so instead it monitors the
+    // live mic through the output engine — same path as hearMyself, gated separately.
+    var previewMonitorEnabled = false
     var recordingMuxedActive = false
     var recordingSeparateActive = false
     var recordingFolder: URL?
@@ -167,7 +200,6 @@ final class TeamTalkConnectionController {
     var fileTransferCommandIDsByTransferID: [Int32: Int32] = [:]
     var securityScopedFileTransferURLs: [Int32: URL] = [:]
     var lastBuiltSessionSnapshot: ConnectedServerSession?
-    var cachedSoundDevices: [SoundDevice] = []
     var cachedAudioDeviceCatalog: AudioDeviceCatalog?
     lazy var advancedMicrophoneEngine = AdvancedMicrophoneAudioEngine { [weak self] chunk in
         self?.queue.async { [weak self] in
@@ -176,6 +208,23 @@ final class TeamTalkConnectionController {
     }
     /// Speaker tap for AEC reference (macOS 14.2+). Typed as Any to avoid availability annotation on stored property.
     var speakerTapCaptureStorage: Any?
+    /// Custom CoreAudio output engine. The SDK renders to the virtual output
+    /// device (TT_SOUNDDEVICE_ID_TEAMTALK_VIRTUAL); we pull the muxed playback PCM
+    /// and render it ourselves, so switching the output device never calls the
+    /// SDK's deadlock-prone TT_CloseSoundOutputDevice. See OutputAudioRenderEngine.
+    let outputRenderEngine = OutputAudioRenderEngine()
+    /// Remote user IDs we currently have per-user audio block events enabled for
+    /// (reconciled with channel membership; the local user is never included).
+    var perUserAudioEnabled: Set<Int32> = []
+    /// Set when channel membership changes; the message loop reconciles per-user
+    /// audio events on its next tick.
+    var perUserAudioNeedsRefresh = false
+    /// Coalesced session-publish state: the message poll is fast (for smooth
+    /// per-user audio), but the expensive full-tree `publishSessionLocked` is
+    /// throttled to ~old cadence so it doesn't rebuild every tick during the
+    /// connect flood (which slowed connecting).
+    var pendingPublishInvalidation: SessionPublishInvalidation = []
+    var lastSnapshotPublishAt: CFAbsoluteTime = 0
 
     init(preferencesStore: AppPreferencesStore) {
         self.preferencesStore = preferencesStore

--- a/App/ttaccessible/Services/UserVolumeStore.swift
+++ b/App/ttaccessible/Services/UserVolumeStore.swift
@@ -80,4 +80,32 @@ final class UserVolumeStore {
         }
         defaults.set(dict, forKey: stereoKey)
     }
+
+    // MARK: - Continuous Pan (Channel Mixer)
+    //
+    // The mixer's pan slider drives OutputAudioRenderEngine.setUserSettings (our own
+    // per-user mix), independent of the SDK's discrete left/right StereoBalance above.
+    // Range -1 (full left) .. 0 (center) .. +1 (full right); center is the default and
+    // is stored as "no entry" so it never overrides a user who only touches the L/R checks.
+
+    private let panKey = "userPanByUsername"
+
+    func pan(forUsername username: String) -> Float? {
+        guard !username.isEmpty,
+              let dict = defaults.dictionary(forKey: panKey),
+              let value = dict[username] as? Double else { return nil }
+        return Float(value)
+    }
+
+    func setPan(_ pan: Float, forUsername username: String) {
+        guard !username.isEmpty else { return }
+        let clamped = max(-1, min(1, pan))
+        var dict = defaults.dictionary(forKey: panKey) ?? [:]
+        if abs(clamped) < 0.0001 {
+            dict.removeValue(forKey: username)
+        } else {
+            dict[username] = Double(clamped)
+        }
+        defaults.set(dict, forKey: panKey)
+    }
 }

--- a/App/ttaccessible/SwiftUI/PreferencesAccessibilityView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAccessibilityView.swift
@@ -11,7 +11,7 @@ struct PreferencesAccessibilityView: View {
     @ObservedObject var store: AccessibilityPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.accessibility.title")) {
             VStack(alignment: .leading, spacing: 14) {
                 Toggle(
                     L10n.text("preferences.accessibility.channelAnnouncements"),

--- a/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
@@ -41,7 +41,7 @@ struct PreferencesAnnouncementsView: View {
     }
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.announcements.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 12) {
                     Text(L10n.text("preferences.notifications.backgroundAnnouncements.title"))

--- a/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAnnouncementsView.swift
@@ -48,17 +48,19 @@ struct PreferencesAnnouncementsView: View {
                         .font(.headline)
                         .accessibilityAddTraits(.isHeader)
 
-                    Toggle(
-                        L10n.text("preferences.notifications.useGlobalMode"),
-                        isOn: Binding(
-                            get: { notificationsStore.state.useGlobalAnnouncementMode },
-                            set: { notificationsStore.updateUseGlobalAnnouncementMode($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { notificationsStore.state.useGlobalAnnouncementMode },
+                        set: { notificationsStore.updateUseGlobalAnnouncementMode($0) }
+                    )) {
+                        Text(L10n.text("preferences.notifications.useGlobalMode"))
+                            .accessibilityHidden(true)
+                    }
+                    .accessibilityLabel(L10n.text("preferences.notifications.useGlobalMode"))
 
                     if notificationsStore.state.useGlobalAnnouncementMode {
                         VStack(alignment: .leading, spacing: 6) {
                             Text(L10n.text("preferences.notifications.globalMode"))
+                                .accessibilityHidden(true)
                             Picker(
                                 L10n.text("preferences.notifications.globalMode"),
                                 selection: Binding(
@@ -77,6 +79,7 @@ struct PreferencesAnnouncementsView: View {
                         ForEach(BackgroundMessageAnnouncementType.allCases) { type in
                             VStack(alignment: .leading, spacing: 6) {
                                 Text(L10n.text(type.titleLocalizationKey))
+                                    .accessibilityHidden(true)
                                 Picker(
                                     L10n.text(type.titleLocalizationKey),
                                     selection: Binding(
@@ -180,32 +183,35 @@ struct PreferencesAnnouncementsView: View {
                         .font(.headline)
                         .accessibilityAddTraits(.isHeader)
 
-                    Toggle(
-                        L10n.text("preferences.accessibility.channelAnnouncements"),
-                        isOn: Binding(
-                            get: { accessibilityStore.state.channelMessagesEnabled },
-                            set: { accessibilityStore.updateVoiceOverChannelMessagesEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { accessibilityStore.state.channelMessagesEnabled },
+                        set: { accessibilityStore.updateVoiceOverChannelMessagesEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.accessibility.channelAnnouncements"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.accessibility.channelAnnouncements"))
 
-                    Toggle(
-                        L10n.text("preferences.accessibility.privateAnnouncements"),
-                        isOn: Binding(
-                            get: { accessibilityStore.state.privateMessagesEnabled },
-                            set: { accessibilityStore.updateVoiceOverPrivateMessagesEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { accessibilityStore.state.privateMessagesEnabled },
+                        set: { accessibilityStore.updateVoiceOverPrivateMessagesEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.accessibility.privateAnnouncements"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.accessibility.privateAnnouncements"))
 
-                    Toggle(
-                        L10n.text("preferences.accessibility.broadcastAnnouncements"),
-                        isOn: Binding(
-                            get: { accessibilityStore.state.broadcastMessagesEnabled },
-                            set: { accessibilityStore.updateVoiceOverBroadcastMessagesEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { accessibilityStore.state.broadcastMessagesEnabled },
+                        set: { accessibilityStore.updateVoiceOverBroadcastMessagesEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.accessibility.broadcastAnnouncements"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.accessibility.broadcastAnnouncements"))
 
                     DisclosureGroup(L10n.text("preferences.accessibility.historyAnnouncements")) {
                         HStack(spacing: 12) {
@@ -226,14 +232,15 @@ struct PreferencesAnnouncementsView: View {
                                 .padding(.top, 4)
 
                             ForEach(group.kinds, id: \.self) { kind in
-                                Toggle(
-                                    L10n.text(kind.localizationKey),
-                                    isOn: Binding(
-                                        get: { accessibilityStore.isSessionHistoryKindEnabled(kind) },
-                                        set: { accessibilityStore.updateSessionHistoryKindEnabled(kind, $0) }
-                                    )
-                                )
+                                Toggle(isOn: Binding(
+                                    get: { accessibilityStore.isSessionHistoryKindEnabled(kind) },
+                                    set: { accessibilityStore.updateSessionHistoryKindEnabled(kind, $0) }
+                                )) {
+                                    Text(L10n.text(kind.localizationKey))
+                                        .accessibilityHidden(true)
+                                }
                                 .toggleStyle(.switch)
+                                .accessibilityLabel(L10n.text(kind.localizationKey))
                             }
                         }
                     }

--- a/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
@@ -17,7 +17,7 @@ struct PreferencesAudioView: View {
     @State private var pushToTalkShortcutConfigured: Bool = KeyboardShortcuts.getShortcut(for: .pushToTalk) != nil
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.audio.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.outputDevice"))

--- a/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesAudioView.swift
@@ -21,6 +21,7 @@ struct PreferencesAudioView: View {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.outputDevice"))
+                        .accessibilityHidden(true)
                     Picker("", selection: $selectedOutputID) {
                         Text(L10n.text("preferences.audio.systemDefault")).tag(defaultDeviceTag)
                         Text(L10n.text("preferences.audio.noOutput")).tag(noOutputDeviceTag)
@@ -37,6 +38,7 @@ struct PreferencesAudioView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.inputDevice"))
+                        .accessibilityHidden(true)
                     Picker("", selection: $selectedInputID) {
                         Text(L10n.text("preferences.audio.systemDefault")).tag(defaultDeviceTag)
                         ForEach(store.state.catalog.inputDevices) { device in
@@ -61,14 +63,15 @@ struct PreferencesAudioView: View {
                         .font(.headline)
                         .accessibilityAddTraits(.isHeader)
 
-                    Toggle(
-                        L10n.text("preferences.audio.advanced.echoCancellation"),
-                        isOn: Binding(
-                            get: { store.advancedPreferences.echoCancellationEnabled },
-                            set: { store.updateEchoCancellationEnabled($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { store.advancedPreferences.echoCancellationEnabled },
+                        set: { store.updateEchoCancellationEnabled($0) }
+                    )) {
+                        Text(L10n.text("preferences.audio.advanced.echoCancellation"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.audio.advanced.echoCancellation"))
 
                     Text(L10n.text("preferences.audio.advanced.echoCancellation.help"))
                         .font(.caption)
@@ -76,6 +79,7 @@ struct PreferencesAudioView: View {
 
                     VStack(alignment: .leading, spacing: 6) {
                         Text(L10n.text("preferences.audio.advanced.preset.label"))
+                            .accessibilityHidden(true)
                         Picker(
                             "",
                             selection: Binding(
@@ -160,6 +164,7 @@ struct PreferencesAudioView: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(L10n.text("preferences.audio.microphoneMode.label"))
+                    .accessibilityHidden(true)
                 Picker(
                     "",
                     selection: Binding(
@@ -180,6 +185,7 @@ struct PreferencesAudioView: View {
             if store.state.microphoneMode == .pushToTalk {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.audio.pushToTalk.key.label"))
+                        .accessibilityHidden(true)
                     KeyboardShortcuts.Recorder(for: .pushToTalk)
                         .accessibilityLabel(L10n.text("preferences.audio.pushToTalk.key.label"))
                 }
@@ -191,14 +197,15 @@ struct PreferencesAudioView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Toggle(
-                    L10n.text("preferences.audio.pushToTalk.beep.label"),
-                    isOn: Binding(
-                        get: { store.state.pushToTalkBeepEnabled },
-                        set: { store.updatePushToTalkBeepEnabled($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.pushToTalkBeepEnabled },
+                    set: { store.updatePushToTalkBeepEnabled($0) }
+                )) {
+                    Text(L10n.text("preferences.audio.pushToTalk.beep.label"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.audio.pushToTalk.beep.label"))
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in

--- a/App/ttaccessible/SwiftUI/PreferencesBearWareView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesBearWareView.swift
@@ -20,7 +20,7 @@ struct PreferencesBearWareView: View {
     private let webLoginClient = BearWareWebLoginClient()
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.bearware.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Text(L10n.text("preferences.bearware.section"))
                     .font(.headline)

--- a/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
@@ -9,7 +9,7 @@ struct PreferencesConnectionView: View {
     @ObservedObject var store: ConnectionPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.connection.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.autoJoinRootChannel"),

--- a/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesConnectionView.swift
@@ -11,59 +11,65 @@ struct PreferencesConnectionView: View {
     var body: some View {
         PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.connection.title")) {
             VStack(alignment: .leading, spacing: 18) {
-                Toggle(
-                    L10n.text("preferences.general.autoJoinRootChannel"),
-                    isOn: Binding(
-                        get: { store.state.autoJoinRootChannel },
-                        set: { store.updateAutoJoinRootChannel($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.autoJoinRootChannel },
+                    set: { store.updateAutoJoinRootChannel($0) }
+                )) {
+                    Text(L10n.text("preferences.general.autoJoinRootChannel"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.autoJoinRootChannel"))
 
-                Toggle(
-                    L10n.text("preferences.general.autoReconnect"),
-                    isOn: Binding(
-                        get: { store.state.autoReconnect },
-                        set: { store.updateAutoReconnect($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.autoReconnect },
+                    set: { store.updateAutoReconnect($0) }
+                )) {
+                    Text(L10n.text("preferences.general.autoReconnect"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.autoReconnect"))
 
-                Toggle(
-                    L10n.text("preferences.general.rejoinLastChannelOnReconnect"),
-                    isOn: Binding(
-                        get: { store.state.rejoinLastChannelOnReconnect },
-                        set: { store.updateRejoinLastChannelOnReconnect($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.rejoinLastChannelOnReconnect },
+                    set: { store.updateRejoinLastChannelOnReconnect($0) }
+                )) {
+                    Text(L10n.text("preferences.general.rejoinLastChannelOnReconnect"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.rejoinLastChannelOnReconnect"))
 
-                Toggle(
-                    L10n.text("preferences.general.connectToLastServerOnLaunch"),
-                    isOn: Binding(
-                        get: { store.state.connectToLastServerOnLaunch },
-                        set: { store.updateConnectToLastServerOnLaunch($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.connectToLastServerOnLaunch },
+                    set: { store.updateConnectToLastServerOnLaunch($0) }
+                )) {
+                    Text(L10n.text("preferences.general.connectToLastServerOnLaunch"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.connectToLastServerOnLaunch"))
 
-                Toggle(
-                    L10n.text("preferences.connection.skipKickConfirmation"),
-                    isOn: Binding(
-                        get: { store.state.skipKickConfirmation },
-                        set: { store.updateSkipKickConfirmation($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.skipKickConfirmation },
+                    set: { store.updateSkipKickConfirmation($0) }
+                )) {
+                    Text(L10n.text("preferences.connection.skipKickConfirmation"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.connection.skipKickConfirmation"))
 
-                Toggle(
-                    L10n.text("preferences.connection.adaptiveJitterBuffer"),
-                    isOn: Binding(
-                        get: { store.state.adaptiveJitterBuffer },
-                        set: { store.updateAdaptiveJitterBuffer($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.adaptiveJitterBuffer },
+                    set: { store.updateAdaptiveJitterBuffer($0) }
+                )) {
+                    Text(L10n.text("preferences.connection.adaptiveJitterBuffer"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.connection.adaptiveJitterBuffer"))
 
                 Picker(
                     L10n.text("preferences.connection.channelSortMode"),
@@ -87,14 +93,15 @@ struct PreferencesConnectionView: View {
                         .accessibilityAddTraits(.isHeader)
 
                     ForEach(UserSubscriptionOption.regularCases, id: \.self) { option in
-                        Toggle(
-                            L10n.text(option.preferencesKey),
-                            isOn: Binding(
-                                get: { store.isSubscriptionEnabledByDefault(option) },
-                                set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
-                            )
-                        )
+                        Toggle(isOn: Binding(
+                            get: { store.isSubscriptionEnabledByDefault(option) },
+                            set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
+                        )) {
+                            Text(L10n.text(option.preferencesKey))
+                                .accessibilityHidden(true)
+                        }
                         .toggleStyle(.switch)
+                        .accessibilityLabel(L10n.text(option.preferencesKey))
                     }
                 }
 
@@ -104,14 +111,15 @@ struct PreferencesConnectionView: View {
                         .accessibilityAddTraits(.isHeader)
 
                     ForEach(UserSubscriptionOption.interceptCases, id: \.self) { option in
-                        Toggle(
-                            L10n.text(option.preferencesKey),
-                            isOn: Binding(
-                                get: { store.isSubscriptionEnabledByDefault(option) },
-                                set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
-                            )
-                        )
+                        Toggle(isOn: Binding(
+                            get: { store.isSubscriptionEnabledByDefault(option) },
+                            set: { enabled in store.updateSubscriptionEnabledByDefault(enabled, for: option) }
+                        )) {
+                            Text(L10n.text(option.preferencesKey))
+                                .accessibilityHidden(true)
+                        }
                         .toggleStyle(.switch)
+                        .accessibilityLabel(L10n.text(option.preferencesKey))
                     }
                 }
             }

--- a/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
@@ -16,7 +16,7 @@ struct PreferencesGeneralView: View {
     @State private var autoAwayCommitTask: Task<Void, Never>?
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.general.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.general.defaultNickname"))

--- a/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesGeneralView.swift
@@ -20,6 +20,7 @@ struct PreferencesGeneralView: View {
             VStack(alignment: .leading, spacing: 18) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.general.defaultNickname"))
+                        .accessibilityHidden(true)
                     TextField("", text: $nicknameDraft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(L10n.text("preferences.general.defaultNickname"))
@@ -35,6 +36,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.defaultStatusMessage"))
+                        .accessibilityHidden(true)
                     TextField("", text: $statusMessageDraft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(L10n.text("preferences.connection.defaultStatusMessage"))
@@ -46,6 +48,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.defaultGender"))
+                        .accessibilityHidden(true)
                     Picker(
                         L10n.text("preferences.connection.defaultGender"),
                         selection: Binding(
@@ -65,6 +68,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.autoAwayTimeout"))
+                        .accessibilityHidden(true)
                     HStack(alignment: .center, spacing: 8) {
                         TextField(
                             "",
@@ -89,6 +93,7 @@ struct PreferencesGeneralView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(L10n.text("preferences.connection.autoAwayStatusMessage"))
+                        .accessibilityHidden(true)
                     TextField("", text: $autoAwayStatusMessageDraft)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(L10n.text("preferences.connection.autoAwayStatusMessage"))
@@ -100,23 +105,25 @@ struct PreferencesGeneralView: View {
 
                 Divider()
 
-                Toggle(
-                    L10n.text("preferences.general.relativeTimestamps"),
-                    isOn: Binding(
-                        get: { rootStore.preferences.useRelativeTimestamps },
-                        set: { rootStore.updateUseRelativeTimestamps($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { rootStore.preferences.useRelativeTimestamps },
+                    set: { rootStore.updateUseRelativeTimestamps($0) }
+                )) {
+                    Text(L10n.text("preferences.general.relativeTimestamps"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.relativeTimestamps"))
 
-                Toggle(
-                    L10n.text("preferences.general.autoDetectImport"),
-                    isOn: Binding(
-                        get: { rootStore.preferences.prefersAutomaticTeamTalkConfigDetection },
-                        set: { rootStore.updatePrefersAutomaticTeamTalkConfigDetection($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { rootStore.preferences.prefersAutomaticTeamTalkConfigDetection },
+                    set: { rootStore.updatePrefersAutomaticTeamTalkConfigDetection($0) }
+                )) {
+                    Text(L10n.text("preferences.general.autoDetectImport"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.autoDetectImport"))
 
                 Divider()
 
@@ -124,24 +131,26 @@ struct PreferencesGeneralView: View {
                     .font(.headline)
                     .accessibilityAddTraits(.isHeader)
 
-                Toggle(
-                    L10n.text("preferences.updates.autoCheck"),
-                    isOn: Binding(
-                        get: { rootStore.preferences.autoCheckForUpdates },
-                        set: { rootStore.updateAutoCheckForUpdates($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { rootStore.preferences.autoCheckForUpdates },
+                    set: { rootStore.updateAutoCheckForUpdates($0) }
+                )) {
+                    Text(L10n.text("preferences.updates.autoCheck"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.updates.autoCheck"))
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Toggle(
-                        L10n.text("preferences.updates.includeBeta"),
-                        isOn: Binding(
-                            get: { rootStore.preferences.includeBetaUpdates },
-                            set: { rootStore.updateIncludeBetaUpdates($0) }
-                        )
-                    )
+                    Toggle(isOn: Binding(
+                        get: { rootStore.preferences.includeBetaUpdates },
+                        set: { rootStore.updateIncludeBetaUpdates($0) }
+                    )) {
+                        Text(L10n.text("preferences.updates.includeBeta"))
+                            .accessibilityHidden(true)
+                    }
                     .toggleStyle(.switch)
+                    .accessibilityLabel(L10n.text("preferences.updates.includeBeta"))
 
                     Text(L10n.text("preferences.updates.includeBeta.help"))
                         .font(.caption)

--- a/App/ttaccessible/SwiftUI/PreferencesImportView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesImportView.swift
@@ -9,7 +9,7 @@ struct PreferencesImportView: View {
     @ObservedObject var store: AppPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.import.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.autoDetectImport"),

--- a/App/ttaccessible/SwiftUI/PreferencesNotificationsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesNotificationsView.swift
@@ -215,7 +215,7 @@ struct PreferencesNotificationsView: View {
     }
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.announcements.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     L10n.text("preferences.general.soundNotifications"),

--- a/App/ttaccessible/SwiftUI/PreferencesPaneScrollView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesPaneScrollView.swift
@@ -6,6 +6,9 @@
 import SwiftUI
 
 struct PreferencesPaneScrollView<Content: View>: View {
+    // Names the scroll area for VoiceOver (it appends the "scroll area" role, so
+    // pass just the pane name, e.g. "General" → "General, scroll area").
+    let accessibilityLabel: String
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -17,5 +20,6 @@ struct PreferencesPaneScrollView<Content: View>: View {
             .padding(24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
@@ -78,14 +78,15 @@ struct PreferencesRecordingView: View {
 
                 Divider()
 
-                Toggle(
-                    L10n.text("preferences.recording.autoRestart"),
-                    isOn: Binding(
-                        get: { store.state.autoRestartRecording },
-                        set: { store.updateAutoRestartRecording($0) }
-                    )
-                )
+                Toggle(isOn: Binding(
+                    get: { store.state.autoRestartRecording },
+                    set: { store.updateAutoRestartRecording($0) }
+                )) {
+                    Text(L10n.text("preferences.recording.autoRestart"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.recording.autoRestart"))
 
                 Text(L10n.text("preferences.recording.help"))
                     .font(.caption)

--- a/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesRecordingView.swift
@@ -9,7 +9,7 @@ struct PreferencesRecordingView: View {
     @ObservedObject var store: RecordingPreferencesStore
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.recording.title")) {
             VStack(alignment: .leading, spacing: 14) {
                 Text(L10n.text("preferences.recording.folder.label"))
                     .font(.headline)

--- a/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
@@ -15,13 +15,20 @@ struct PreferencesSoundsView: View {
         PreferencesPaneScrollView {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
-                    L10n.text("preferences.general.soundNotifications"),
                     isOn: Binding(
                         get: { store.state.soundNotificationsEnabled },
                         set: { store.updateSoundNotificationsEnabled($0) }
                     )
-                )
+                ) {
+                    // Visible label, but hidden from accessibility so macOS doesn't
+                    // expose it as a separate static-text stop next to the switch.
+                    // The switch keeps its native role; its name comes from
+                    // .accessibilityLabel below.
+                    Text(L10n.text("preferences.general.soundNotifications"))
+                        .accessibilityHidden(true)
+                }
                 .toggleStyle(.switch)
+                .accessibilityLabel(L10n.text("preferences.general.soundNotifications"))
 
                 HStack(spacing: 12) {
                     Picker(
@@ -92,13 +99,19 @@ struct PreferencesSoundsView: View {
 
                     ForEach(NotificationSound.allCases, id: \.self) { sound in
                         Toggle(
-                            L10n.text(sound.localizationKey),
                             isOn: Binding(
                                 get: { store.isSoundEventEnabled(sound) },
                                 set: { store.setSoundEventEnabled(sound, enabled: $0) }
                             )
-                        )
+                        ) {
+                            // Visible label hidden from accessibility so it isn't a
+                            // separate static-text stop; the switch keeps its native
+                            // role and gets its name from .accessibilityLabel below.
+                            Text(L10n.text(sound.localizationKey))
+                                .accessibilityHidden(true)
+                        }
                         .toggleStyle(.switch)
+                        .accessibilityLabel(L10n.text(sound.localizationKey))
                     }
                 }
             }

--- a/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
+++ b/App/ttaccessible/SwiftUI/PreferencesSoundsView.swift
@@ -12,7 +12,7 @@ struct PreferencesSoundsView: View {
     @State private var availablePacks = SoundPlayer.availablePacks
 
     var body: some View {
-        PreferencesPaneScrollView {
+        PreferencesPaneScrollView(accessibilityLabel: L10n.text("preferences.sounds.title")) {
             VStack(alignment: .leading, spacing: 18) {
                 Toggle(
                     isOn: Binding(

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -950,6 +950,7 @@
 "toolbar.recording.stop" = "Stop recording";
 "toolbar.recording.stop.tooltip" = "Stop recording (⌘R)";
 "toolbar.hearMyself" = "Hear myself";
+"toolbar.hearMyself.selected" = "Hear myself, selected";
 "toolbar.hearMyself.tooltip" = "Toggle hearing yourself (⌘⇧H)";
 "preferences.updates.section" = "Updates";
 "preferences.updates.autoCheck" = "Check for updates automatically";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -658,6 +658,9 @@
 "mixer.muted.media" = "media muted";
 "mixer.area.label" = "Mixer";
 "mixer.area.roleDescription" = "area";
+"mixer.strip.roleDescription" = "channel strip";
+"mixer.control.slider.roleDescription" = "slider";
+"mixer.control.button.roleDescription" = "button";
 "mixer.voice.label.short" = "Volume";
 "mixer.media.label.short" = "Media volume";
 "mixer.pan.label.short" = "Pan";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -210,8 +210,8 @@
 "connectedServer.volume.sliderLabel" = "Volume percentage";
 "connectedServer.volume.voice" = "Voice";
 "connectedServer.volume.mediaFile" = "Media file";
-"connectedServer.volume.voiceSliderLabel" = "Voice volume percentage";
-"connectedServer.volume.mediaFileSliderLabel" = "Media file volume percentage";
+"connectedServer.volume.voiceSliderLabel" = "Voice volume";
+"connectedServer.volume.mediaFileSliderLabel" = "Media file volume";
 "connectedServer.menu.makeOperator" = "Make channel operator";
 "connectedServer.menu.revokeOperator" = "Revoke channel operator";
 "user.menu.makeOperator" = "Make channel operator";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -350,7 +350,7 @@
 "preferences.notifications.tts.volume" = "Volume";
 "preferences.notifications.tts.volume.value" = "%@%%";
 "preferences.notifications.tts.test" = "Test voice";
-"preferences.notifications.tts.testPhrase" = "This is a TTAccessible speech test.";
+"preferences.notifications.tts.testPhrase" = "This is a tt-Accessible speech test.";
 "preferences.import.title" = "Import";
 "preferences.general.defaultNickname" = "Default nickname";
 "preferences.general.defaultNickname.help" = "Used when a saved server has no specific nickname.";

--- a/App/ttaccessible/en.lproj/Localizable.strings
+++ b/App/ttaccessible/en.lproj/Localizable.strings
@@ -139,6 +139,8 @@
 "connectedServer.audio.inputGain.accessibilityLabel" = "Microphone input volume";
 "connectedServer.audio.outputGain.label" = "Output volume";
 "connectedServer.audio.outputGain.accessibilityLabel" = "Audio output volume";
+"connectedServer.audio.soundEffectsGain.label" = "Sound effects volume";
+"connectedServer.audio.soundEffectsGain.accessibilityLabel" = "Sound effects volume";
 "connectedServer.audio.gain.resetAccessibilityAction" = "Reset to 50%";
 "connectedServer.audio.voiceEnabled" = "Microphone enabled.";
 "connectedServer.audio.voiceDisabled" = "Microphone muted.";
@@ -638,6 +640,36 @@
 "files.window.title" = "Channel Files";
 "files.menu.open" = "Channel Files";
 "files.menu.upload" = "Upload a File…";
+
+/* Channel Mixer */
+"mixer.menu.open" = "Channel Mixer";
+"mixer.window.title" = "Channel Mixer";
+"mixer.empty" = "No other users in this channel.";
+"mixer.voice.label" = "Voice volume, %@";
+"mixer.media.label" = "Media volume, %@";
+"mixer.pan.label" = "Pan, %@";
+"mixer.mute.voice" = "Mute voice, %@";
+"mixer.mute.media" = "Mute media, %@";
+"mixer.value.percent" = "%d%%";
+"mixer.pan.center" = "Center";
+"mixer.pan.left" = "Left %d%%";
+"mixer.pan.right" = "Right %d%%";
+"mixer.muted.voice" = "voice muted";
+"mixer.muted.media" = "media muted";
+"mixer.area.label" = "Mixer";
+"mixer.area.roleDescription" = "area";
+"mixer.voice.label.short" = "Volume";
+"mixer.media.label.short" = "Media volume";
+"mixer.pan.label.short" = "Pan";
+"mixer.mute.label.short" = "Mute";
+"mixer.mute.action.mute" = "Mute";
+"mixer.mute.action.unmute" = "Unmute";
+"mixer.solo.action.solo" = "Solo";
+"mixer.solo.action.unsolo" = "Unsolo";
+"mixer.solo.on" = "soloed";
+"mixer.solo.off" = "unsoloed";
+"mixer.toggle.muted" = "muted";
+"mixer.toggle.unmuted" = "unmuted";
 "files.empty" = "No files in this channel.";
 "files.column.name" = "Name";
 "files.column.size" = "Size";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -350,7 +350,7 @@
 "preferences.notifications.tts.volume" = "Volume";
 "preferences.notifications.tts.volume.value" = "%@%%";
 "preferences.notifications.tts.test" = "Tester la voix";
-"preferences.notifications.tts.testPhrase" = "Ceci est un test de la synthèse vocale de TTAccessible.";
+"preferences.notifications.tts.testPhrase" = "Ceci est un test de la synthèse vocale de tt-Accessible.";
 "preferences.import.title" = "Import";
 "preferences.general.defaultNickname" = "Pseudo par défaut";
 "preferences.general.defaultNickname.help" = "Utilisé quand un serveur enregistré n'a pas de pseudo spécifique.";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -658,6 +658,9 @@
 "mixer.muted.media" = "média coupé";
 "mixer.area.label" = "Mixeur";
 "mixer.area.roleDescription" = "zone";
+"mixer.strip.roleDescription" = "tranche de console";
+"mixer.control.slider.roleDescription" = "curseur";
+"mixer.control.button.roleDescription" = "bouton";
 "mixer.voice.label.short" = "Volume";
 "mixer.media.label.short" = "Volume du média";
 "mixer.pan.label.short" = "Panoramique";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -139,6 +139,8 @@
 "connectedServer.audio.inputGain.accessibilityLabel" = "Volume d'entrée du microphone";
 "connectedServer.audio.outputGain.label" = "Volume de sortie";
 "connectedServer.audio.outputGain.accessibilityLabel" = "Volume de sortie audio";
+"connectedServer.audio.soundEffectsGain.label" = "Volume des effets sonores";
+"connectedServer.audio.soundEffectsGain.accessibilityLabel" = "Volume des effets sonores";
 "connectedServer.audio.gain.resetAccessibilityAction" = "Réinitialiser à 50 %";
 "connectedServer.audio.voiceEnabled" = "Micro activé.";
 "connectedServer.audio.voiceDisabled" = "Micro coupé.";
@@ -638,6 +640,36 @@
 "files.window.title" = "Fichiers du canal";
 "files.menu.open" = "Fichiers du canal";
 "files.menu.upload" = "Envoyer un fichier…";
+
+/* Mixeur du canal */
+"mixer.menu.open" = "Mixeur du canal";
+"mixer.window.title" = "Mixeur du canal";
+"mixer.empty" = "Aucun autre utilisateur dans ce canal.";
+"mixer.voice.label" = "Volume de la voix, %@";
+"mixer.media.label" = "Volume du média, %@";
+"mixer.pan.label" = "Panoramique, %@";
+"mixer.mute.voice" = "Couper la voix, %@";
+"mixer.mute.media" = "Couper le média, %@";
+"mixer.value.percent" = "%d %%";
+"mixer.pan.center" = "Centre";
+"mixer.pan.left" = "Gauche %d %%";
+"mixer.pan.right" = "Droite %d %%";
+"mixer.muted.voice" = "voix coupée";
+"mixer.muted.media" = "média coupé";
+"mixer.area.label" = "Mixeur";
+"mixer.area.roleDescription" = "zone";
+"mixer.voice.label.short" = "Volume";
+"mixer.media.label.short" = "Volume du média";
+"mixer.pan.label.short" = "Panoramique";
+"mixer.mute.label.short" = "Sourdine";
+"mixer.mute.action.mute" = "Couper le son";
+"mixer.mute.action.unmute" = "Rétablir le son";
+"mixer.solo.action.solo" = "Solo";
+"mixer.solo.action.unsolo" = "Annuler le solo";
+"mixer.solo.on" = "solo activé";
+"mixer.solo.off" = "solo désactivé";
+"mixer.toggle.muted" = "coupé";
+"mixer.toggle.unmuted" = "rétabli";
 "files.empty" = "Aucun fichier dans ce canal.";
 "files.column.name" = "Nom";
 "files.column.size" = "Taille";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -210,8 +210,8 @@
 "connectedServer.volume.sliderLabel" = "Volume en pourcentage";
 "connectedServer.volume.voice" = "Voix";
 "connectedServer.volume.mediaFile" = "Fichier média";
-"connectedServer.volume.voiceSliderLabel" = "Volume de la voix en pourcentage";
-"connectedServer.volume.mediaFileSliderLabel" = "Volume du fichier média en pourcentage";
+"connectedServer.volume.voiceSliderLabel" = "Volume de la voix";
+"connectedServer.volume.mediaFileSliderLabel" = "Volume du fichier média";
 "connectedServer.menu.makeOperator" = "Promouvoir opérateur de canal";
 "connectedServer.menu.revokeOperator" = "Révoquer opérateur de canal";
 "user.menu.makeOperator" = "Promouvoir opérateur de canal";

--- a/App/ttaccessible/fr.lproj/Localizable.strings
+++ b/App/ttaccessible/fr.lproj/Localizable.strings
@@ -950,6 +950,7 @@
 "toolbar.recording.stop" = "Arrêter l'enregistrement";
 "toolbar.recording.stop.tooltip" = "Arrêter l'enregistrement (⌘R)";
 "toolbar.hearMyself" = "M'entendre";
+"toolbar.hearMyself.selected" = "M'entendre, sélectionné";
 "toolbar.hearMyself.tooltip" = "Activer / désactiver l'écoute de soi (⌘⇧H)";
 "preferences.updates.section" = "Mises à jour";
 "preferences.updates.autoCheck" = "Vérifier les mises à jour automatiquement";

--- a/App/ttaccessible/ttaccessible-Bridging-Header.h
+++ b/App/ttaccessible/ttaccessible-Bridging-Header.h
@@ -1,2 +1,3 @@
 #include "../../Vendor/TeamTalk/TeamTalk.h"
 #include "../../Vendor/WebRTC/WebRTCEchoCanceller.h"
+#include "AudioRTSupport.h"

--- a/scripts/download-sdk.sh
+++ b/scripts/download-sdk.sh
@@ -51,6 +51,12 @@ echo "Installing to Vendor/TeamTalk/..."
 cp "$TEMP_DIR/${SDK_DIR}/Library/TeamTalk_DLL/libTeamTalk5.dylib" "$VENDOR_DIR/"
 cp "$TEMP_DIR/${SDK_DIR}/Library/TeamTalk_DLL/TeamTalk.h" "$VENDOR_DIR/"
 
+# Skip PortAudio's startup device probe (the ~13 s "slow connect" on large rigs).
+# See scripts/patch-sdk-portaudio.py for the full rationale. The freshly downloaded
+# dylib is the unmodified BearWare build, so re-apply the patch on every download.
+echo "Patching out PortAudio's startup device probe..."
+python3 "$(dirname "$0")/patch-sdk-portaudio.py" "$VENDOR_DIR/libTeamTalk5.dylib"
+
 echo ""
-echo "Done. SDK ${SDK_VERSION} installed:"
+echo "Done. SDK ${SDK_VERSION} installed (PortAudio probe patched):"
 ls -lh "$VENDOR_DIR/libTeamTalk5.dylib" "$VENDOR_DIR/TeamTalk.h"

--- a/scripts/patch-sdk-portaudio.py
+++ b/scripts/patch-sdk-portaudio.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Patch libTeamTalk5.dylib so PortAudio's startup device probe is skipped.
+
+WHY: TT_InitTeamTalkPoll (SDK instance creation) makes the bundled PortAudio probe
+every audio device's supported sample rates by actually opening+closing a CoreAudio
+stream for each device x each standard rate (~956 stream opens on a large rig). That
+is the ~13 s "slow connect" on Rocco's machine. The probe lives in PortAudio's
+IsFormatSupported() (pa_mac_core.c), which calls OpenStream just to test a format.
+
+THE PATCH: overwrite IsFormatSupported's prologue so it returns paFormatIsSupported (0)
+immediately, before opening anything. This is safe for ttAccessible because the app
+never uses a real PortAudio device — input and output both go through the TeamTalk
+virtual device (TT_SOUNDDEVICE_ID_TEAMTALK_VIRTUAL) feeding our own CoreAudio engines.
+Verified: device enumeration (TT_GetSoundDevices) and virtual-device init are byte-for-
+byte identical to the unpatched dylib; first TT_InitTeamTalkPoll drops 13.3 s -> 0.2 s.
+
+Symbol-driven (finds _IsFormatSupported via nm per arch) so it survives SDK version
+bumps where the offset moves. Idempotent: re-running is a no-op. Patches every arch
+slice (arm64 + x86_64) in the universal dylib, then re-signs adhoc.
+
+Usage: scripts/patch-sdk-portaudio.py [path/to/libTeamTalk5.dylib]
+"""
+import subprocess, sys, os, struct
+
+# "return paFormatIsSupported (0)" stubs, per arch:
+STUBS = {
+    "arm64":  bytes([0x00,0x00,0x80,0x52, 0xc0,0x03,0x5f,0xd6]),  # mov w0,#0 ; ret
+    "x86_64": bytes([0x31,0xc0, 0xc3]),                            # xor eax,eax ; ret
+}
+SYMBOL = "_IsFormatSupported"
+
+def fat_slice_offsets(path):
+    """arch -> file offset of its Mach-O slice (0 if thin)."""
+    out = subprocess.check_output(["otool", "-f", path], text=True, stderr=subprocess.DEVNULL)
+    offs, cur = {}, None
+    cputype_to_arch = {16777223: "x86_64", 16777228: "arm64"}
+    for line in out.splitlines():
+        s = line.strip()
+        if s.startswith("cputype"):
+            cur = cputype_to_arch.get(int(s.split()[1]))
+        elif s.startswith("offset") and cur:
+            offs[cur] = int(s.split()[1]); cur = None
+    if not offs:  # thin binary
+        a = subprocess.check_output(["lipo", "-info", path], text=True).split(":")[-1].strip()
+        offs[a] = 0
+    return offs
+
+def symbol_vmaddr(path, arch):
+    out = subprocess.check_output(["nm", "-arch", arch, path], text=True, stderr=subprocess.DEVNULL)
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == SYMBOL:
+            return int(parts[0], 16)
+    return None
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+        os.path.dirname(__file__), "..", "Vendor", "TeamTalk", "libTeamTalk5.dylib")
+    path = os.path.abspath(path)
+    if not os.path.exists(path):
+        print(f"error: {path} not found", file=sys.stderr); sys.exit(1)
+
+    slices = fat_slice_offsets(path)
+    data = bytearray(open(path, "rb").read())
+    patched, skipped = [], []
+    for arch, slice_off in slices.items():
+        stub = STUBS.get(arch)
+        if not stub:
+            print(f"  {arch}: no stub defined, skipping"); continue
+        vm = symbol_vmaddr(path, arch)
+        if vm is None:
+            print(f"  {arch}: {SYMBOL} not found, skipping"); continue
+        off = slice_off + vm  # __TEXT.vmaddr is 0, fileoff 0 -> file offset = slice + vmaddr
+        cur = bytes(data[off:off+len(stub)])
+        if cur == stub:
+            skipped.append(arch); continue
+        data[off:off+len(stub)] = stub
+        patched.append(f"{arch}@0x{off:X}")
+
+    if not patched:
+        print(f"Already patched ({', '.join(skipped) or 'no slices'}). No change."); return
+
+    open(path, "wb").write(data)
+    print("Patched IsFormatSupported -> return-supported in:", ", ".join(patched))
+    if skipped: print("  (already patched:", ", ".join(skipped) + ")")
+    subprocess.check_call(["codesign", "--force", "--sign", "-", path])
+    subprocess.check_call(["codesign", "--verify", path])
+    print("Re-signed adhoc and verified.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch-sdk-portaudio.py
+++ b/scripts/patch-sdk-portaudio.py
@@ -19,6 +19,13 @@ Symbol-driven (finds _IsFormatSupported via nm per arch) so it survives SDK vers
 bumps where the offset moves. Idempotent: re-running is a no-op. Patches every arch
 slice (arm64 + x86_64) in the universal dylib, then re-signs adhoc.
 
+FAILS LOUDLY: before overwriting, the bytes at the symbol are checked against an
+allowlist of the known-good unpatched prologue (per arch). If a future SDK keeps the
+symbol but emits a different prologue, those bytes won't match -> the script aborts
+(exit 1) instead of clobbering an unknown instruction stream and shipping a corrupt
+dylib. The file-offset math (off = slice_off + symbol_vmaddr) is only valid when the
+__TEXT segment has vmaddr==0 and fileoff==0, so that is asserted explicitly per arch.
+
 Usage: scripts/patch-sdk-portaudio.py [path/to/libTeamTalk5.dylib]
 """
 import subprocess, sys, os, struct
@@ -27,6 +34,13 @@ import subprocess, sys, os, struct
 STUBS = {
     "arm64":  bytes([0x00,0x00,0x80,0x52, 0xc0,0x03,0x5f,0xd6]),  # mov w0,#0 ; ret
     "x86_64": bytes([0x31,0xc0, 0xc3]),                            # xor eax,eax ; ret
+}
+# Allowlist of the known-good UNPATCHED prologue bytes the stub overwrites (same length
+# as the stub, per arch). Captured from the BearWare v5.22a universal build. A new SDK
+# may legitimately add entries here, but a SILENT mismatch must never be patched over.
+ORIGINAL_PROLOGUES = {
+    "arm64":  [bytes([0xff,0x43,0x01,0xd1, 0xe9,0x23,0x02,0x6d])],  # sub sp,sp,#0x50 ; stp d9,d8,[sp,#0x20]
+    "x86_64": [bytes([0x55, 0x48,0x89])],                           # push rbp ; (mov rbp,rsp)
 }
 SYMBOL = "_IsFormatSupported"
 
@@ -54,6 +68,25 @@ def symbol_vmaddr(path, arch):
             return int(parts[0], 16)
     return None
 
+def text_segment_origin(path, arch):
+    """(__TEXT.vmaddr, __TEXT.fileoff) for the given arch slice.
+
+    The offset math `off = slice_off + symbol_vmaddr` is only correct when both are 0
+    (so a symbol's vmaddr equals its offset inside the slice). Returns them so the
+    caller can assert that assumption rather than trusting it blindly."""
+    out = subprocess.check_output(["otool", "-arch", arch, "-l", path], text=True, stderr=subprocess.DEVNULL)
+    in_text, vmaddr, fileoff = False, None, None
+    for line in out.splitlines():
+        s = line.strip()
+        if s.startswith("segname "):
+            in_text = (s.split()[1] == "__TEXT")
+        elif in_text and s.startswith("vmaddr ") and vmaddr is None:
+            vmaddr = int(s.split()[1], 16)
+        elif in_text and s.startswith("fileoff ") and fileoff is None:
+            fileoff = int(s.split()[1])
+            break
+    return vmaddr, fileoff
+
 def main():
     path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
         os.path.dirname(__file__), "..", "Vendor", "TeamTalk", "libTeamTalk5.dylib")
@@ -71,10 +104,26 @@ def main():
         vm = symbol_vmaddr(path, arch)
         if vm is None:
             print(f"  {arch}: {SYMBOL} not found, skipping"); continue
-        off = slice_off + vm  # __TEXT.vmaddr is 0, fileoff 0 -> file offset = slice + vmaddr
+        # off = slice_off + symbol_vmaddr is only valid when __TEXT is mapped at vmaddr 0
+        # with fileoff 0. Assert it instead of assuming it.
+        tvm, tfo = text_segment_origin(path, arch)
+        if tvm != 0 or tfo != 0:
+            print(f"error: {arch} __TEXT vmaddr=0x{tvm:X} fileoff={tfo}, expected 0/0 — "
+                  f"offset math is invalid for this layout. Aborting.", file=sys.stderr)
+            sys.exit(1)
+        off = slice_off + vm  # __TEXT.vmaddr==0, fileoff==0 -> file offset = slice + vmaddr
         cur = bytes(data[off:off+len(stub)])
         if cur == stub:
             skipped.append(arch); continue
+        # Fail loudly rather than clobber an unknown prologue (e.g. a future SDK whose
+        # IsFormatSupported keeps its symbol but changes its instructions).
+        if cur not in ORIGINAL_PROLOGUES.get(arch, []):
+            print(f"error: {arch} {SYMBOL} prologue at 0x{off:X} is {cur.hex()}, which is "
+                  f"neither the patched stub nor a known unpatched prologue. The SDK build "
+                  f"likely changed — refusing to patch (would corrupt the dylib). Update "
+                  f"ORIGINAL_PROLOGUES['{arch}'] after verifying the new prologue by hand.",
+                  file=sys.stderr)
+            sys.exit(1)
         data[off:off+len(stub)] = stub
         patched.append(f"{arch}@0x{off:X}")
 


### PR DESCRIPTION
Hi Mathieu — the audio set we discussed: the cohesive unit you said you'd want to test with a couple of people. **Stacked on #21** (the accessibility PR) — please merge #21 first; until then this PR's diff also shows #21's commits, and it'll collapse to audio-only once #21 lands.

## What it does

- **Output-bypass render engine** — the SDK points at the TeamTalk *virtual* output device, and we render each remote user's decoded PCM ourselves via `OutputAudioRenderEngine`. Switching the active output device never closes a live SDK output device → cures the intermittent `TT_CloseSoundOutputDevice` deadlock on macOS. The same approach removes the input-side hazard.
- **CoreAudio UID-keyed device prefs** — the device catalog is built from CoreAudio and remembered by stable UID across launches/hot-plug (not the SDK's reshuffling integer index, which could silently select the wrong device on restart).
- **Channel Mixer** — a live per-user voice/media/pan/mute/solo desk embedded in the main window, with full keyboard control, built for VoiceOver.
- **Faster connect** — a targeted patch to PortAudio's slow startup device probe (`scripts/patch-sdk-portaudio.py`, run from `download-sdk.sh`) plus instance prewarm/reuse: ~13s → ~0.2s first connect on large rigs.

## Your earlier question, answered

Per-user voice **and** media-file volume and mute all remain audible through `TT_SetUserVolume` / `TT_SetUserMute` in the bypass path (confirmed by listening) — the decoded per-user PCM we render reflects those SDK settings.

## Mixer keyboard shortcuts

While VoiceOver is focused on a mixer strip:

- **↑ / ↓** — focused user's **voice** volume
- **⌘↑ / ⌘↓** — focused user's **media** volume (or **master output** volume when the cursor is *not* on a strip)
- **← / →** — focused user's **pan**
- **v** — announce volume (tap) · reset to 50% (double-tap)
- **p** — announce pan (tap) · reset to center (double-tap)
- **m** — announce mute (tap) · toggle mute (double-tap)
- **s** — announce solo (tap) · toggle solo (double-tap)

Heads-up: I forgot to add any in-app documentation for these — no help tags, no shortcuts reference in the UI — so right now they're only written down here. Making them discoverable in-app (help tags / a shortcuts list, ideally VoiceOver-friendly) is a good follow-up; happy to do that in a separate PR.

## Worth flagging honestly

- This is an **architectural change**, not just patches — it's been stable in daily use here, but it deserves real multi-person testing (exactly what you wanted to do), not a rubber stamp.
- It **patches the bundled TeamTalk SDK dylib** — you already added a safety check to the script so a future SDK layout change fails loudly; thank you for that.
- One open item we're still chasing: on a heavy aggregate / Rogue Amoeba Loopback setup, a CoreAudio device-list storm can disrupt other virtual audio devices. It's under investigation; the app's own render engine stays healthy through it.

Happy to split this further or adjust anything.
