### PR TITLE
Audio: fix choppy playback on channels with large voice packets (60–120 ms)

### DIFF
--- a/App/ttaccessible/AudioRTSupport.h
+++ b/App/ttaccessible/AudioRTSupport.h
@@ -17,6 +17,8 @@
 #define AUDIO_RT_SUPPORT_H
 
 #include <stdatomic.h>
+#include <stdint.h>
+#include <string.h>
 
 /// Acquire fence: all reads after this see writes published before the
 /// matching release fence on the other thread.
@@ -28,6 +30,109 @@ static inline void ttac_atomic_fence_acquire(void) {
 /// matching acquire fence.
 static inline void ttac_atomic_fence_release(void) {
     atomic_thread_fence(memory_order_release);
+}
+
+// MARK: - Per-sample hot loops
+//
+// The mixer's per-frame summing and the render callback's deinterleave/convert
+// loops live here in C, NOT in Swift. Unoptimized (-Onone) Swift runs these
+// loops through range iterators, generic integer/float initializers and
+// witness-table lookups — measured slow enough on a Debug build to miss HAL
+// deadlines (audible device-level glitching) on a multi-channel interface.
+// Plain C compiles to tight loops in every build configuration, so Debug and
+// Release behave identically in the real-time path. Everything here is
+// RT-safe: no allocation, no locks, no ObjC.
+
+/// Zero `count` accumulator slots.
+static inline void ttac_mix_clear(int32_t *acc, int count) {
+    memset(acc, 0, (size_t)count * sizeof(int32_t));
+}
+
+/// Accumulate one source's interleaved PCM into the stereo Int32 accumulator
+/// with per-side gains. `channels` 1 = mono (duplicated to both sides),
+/// otherwise the first two interleaved channels are used. Truncation toward
+/// zero matches the previous Swift `Int(Float * Float)` behavior.
+static inline void ttac_mix_add(int32_t *acc,
+                                const int16_t *src,
+                                int frames,
+                                int channels,
+                                float leftGain,
+                                float rightGain) {
+    if (channels == 1) {
+        for (int f = 0; f < frames; f++) {
+            const float s = (float)src[f];
+            acc[f * 2] += (int32_t)(s * leftGain);
+            acc[f * 2 + 1] += (int32_t)(s * rightGain);
+        }
+    } else {
+        for (int f = 0; f < frames; f++) {
+            acc[f * 2] += (int32_t)((float)src[f * channels] * leftGain);
+            acc[f * 2 + 1] += (int32_t)((float)src[f * channels + 1] * rightGain);
+        }
+    }
+}
+
+/// Clamp the Int32 accumulator into interleaved Int16 output.
+static inline void ttac_mix_clamp(int16_t *out, const int32_t *acc, int count) {
+    for (int i = 0; i < count; i++) {
+        int32_t v = acc[i];
+        if (v > INT16_MAX) v = INT16_MAX;
+        else if (v < INT16_MIN) v = INT16_MIN;
+        out[i] = (int16_t)v;
+    }
+}
+
+/// Render the interleaved stereo Int16 pull buffer into the device's
+/// non-interleaved Float planes with per-frame gain smoothing.
+/// - planes: `devCh` non-null plane pointers (caller has already null-checked).
+/// - framesAvailable: frames actually pulled from the ring; the remainder up
+///   to `frameCount` is filled with silence (gain smoothing still advances).
+/// - devCh == 1 downmixes L/R by average; devCh >= 2 maps L->0, R->1 and
+///   silences the extra channels.
+/// Returns the smoothed gain after `frameCount` frames.
+static inline float ttac_render_planes(float *const *planes,
+                                       int devCh,
+                                       const int16_t *pull,
+                                       int framesAvailable,
+                                       int frameCount,
+                                       float gain,
+                                       float gainTarget,
+                                       float smoothCoeff) {
+    const float invScale = 1.0f / 32768.0f;
+    for (int ch = 2; ch < devCh; ch++) {
+        memset(planes[ch], 0, (size_t)frameCount * sizeof(float));
+    }
+    if (devCh == 1) {
+        float *mono = planes[0];
+        for (int f = 0; f < framesAvailable; f++) {
+            gain += (gainTarget - gain) * smoothCoeff;
+            const int32_t sum = ((int32_t)pull[f * 2] + (int32_t)pull[f * 2 + 1]) / 2;
+            mono[f] = (float)sum * invScale * gain;
+        }
+        if (framesAvailable < frameCount) {
+            memset(mono + framesAvailable, 0,
+                   (size_t)(frameCount - framesAvailable) * sizeof(float));
+        }
+    } else {
+        float *left = planes[0];
+        float *right = planes[1];
+        for (int f = 0; f < framesAvailable; f++) {
+            gain += (gainTarget - gain) * smoothCoeff;
+            const float g = invScale * gain;
+            left[f] = (float)pull[f * 2] * g;
+            right[f] = (float)pull[f * 2 + 1] * g;
+        }
+        if (framesAvailable < frameCount) {
+            const size_t tail = (size_t)(frameCount - framesAvailable) * sizeof(float);
+            memset(left + framesAvailable, 0, tail);
+            memset(right + framesAvailable, 0, tail);
+        }
+    }
+    // Keep the smoothing state exact across the silent tail.
+    for (int f = framesAvailable; f < frameCount; f++) {
+        gain += (gainTarget - gain) * smoothCoeff;
+    }
+    return gain;
 }
 
 #endif /* AUDIO_RT_SUPPORT_H */

--- a/App/ttaccessible/Services/AudioBlockPump.swift
+++ b/App/ttaccessible/Services/AudioBlockPump.swift
@@ -1,0 +1,166 @@
+//
+//  AudioBlockPump.swift
+//  ttaccessible
+//
+//  Drains per-user audio blocks from the TeamTalk SDK on a dedicated
+//  high-priority timer, decoupled from the 20 ms message loop.
+//
+//  WHY: audio blocks used to be acquired inside the message-loop drain
+//  (CLIENTEVENT_USER_AUDIOBLOCK → TT_AcquireUserAudioBlock) on the
+//  controller's serial queue. That queue also runs the channel-tree
+//  publish, history appends and VU/state updates — all of which grow
+//  with the number of users in the channel. In a crowded channel a
+//  single slow tick (longer than the ~25 ms per-user jitter buffer)
+//  starves EVERY mix source at once, so everyone's audio went choppy
+//  simultaneously — while the render engine reported zero ring
+//  underflows (the gap is upstream of the ring). Acquiring blocks on a
+//  queue that does nothing else makes delivery immune to message-loop
+//  congestion without adding any buffering (= no added latency).
+//
+//  Threading: all state is confined to `queue`. The TeamTalk C API is
+//  internally synchronized per client instance, so acquiring blocks here
+//  while the message loop makes other TT_* calls is safe (the codebase
+//  already calls TT functions from multiple queues, e.g. the prewarm
+//  path). Ordering is preserved because this pump is the ONLY acquirer
+//  for its stream keys and `OutputAudioRenderEngine.enqueueUser` hops to
+//  a serial queue. `stop()` is synchronous: once it returns, no further
+//  SDK calls are made — the controller relies on that during teardown.
+//
+//  The muxed stream (TT_MUXED_USERID, the pre-14.2 AEC reference
+//  fallback) intentionally stays on the message loop: its consumer is
+//  queue-confined and reference timing tolerates the loop's jitter.
+//
+
+import Foundation
+
+final class AudioBlockPump {
+    private let queue = DispatchQueue(label: "com.ttaccessible.audio-block-pump", qos: .userInteractive)
+    private var timer: DispatchSourceTimer?
+    private var instance: UnsafeMutableRawPointer?
+    private weak var engine: OutputAudioRenderEngine?
+    /// Remote users whose per-user block events are enabled (mirrors the
+    /// controller's `perUserAudioEnabled`).
+    private var userIDs: [Int32] = []
+    /// Whether our OWN media-file stream (TT_LOCAL_USERID) is subscribed
+    /// (mirrors the controller's `localMediaAudioEnabled`).
+    private var localMediaEnabled = false
+
+    /// ~4× the usual block cadence (~40 ms OPUS frames): a queued block never
+    /// waits long, and a tick on an empty queue is just a lock + check per
+    /// enabled stream.
+    private let tickMS = 10
+    /// Safety bound per (user, stream) per tick; normal traffic is 1–2 blocks.
+    private let maxBlocksPerStreamPerTick = 16
+
+    /// Begin pumping for `instance`, feeding decoded PCM into `engine`.
+    /// Synchronous so the user set pushed right after lands on a running pump.
+    func start(instance: UnsafeMutableRawPointer, engine: OutputAudioRenderEngine) {
+        queue.sync {
+            stopTimerLocked()
+            self.instance = instance
+            self.engine = engine
+            let timer = DispatchSource.makeTimerSource(queue: queue)
+            timer.schedule(deadline: .now() + .milliseconds(tickMS),
+                           repeating: .milliseconds(tickMS), leeway: .milliseconds(2))
+            timer.setEventHandler { [weak self] in self?.tick() }
+            self.timer = timer
+            timer.resume()
+        }
+    }
+
+    /// Synchronous: after this returns the pump makes no further SDK calls.
+    func stop() {
+        queue.sync {
+            stopTimerLocked()
+            instance = nil
+            engine = nil
+            userIDs = []
+            localMediaEnabled = false
+        }
+    }
+
+    /// Reconcile the drained user set. Departed users' mix sources are removed
+    /// HERE (not by the controller) so removal is ordered after this pump's
+    /// final enqueue for that user — no ghost source can be recreated by a
+    /// block acquired in the same tick.
+    func setUsers(_ users: Set<Int32>) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let departed = Set(self.userIDs).subtracting(users)
+            self.userIDs = Array(users)
+            if let engine = self.engine {
+                for userID in departed {
+                    engine.removeUser(userID)
+                    engine.removeUser(TeamTalkConnectionController.outputMediaSourceKey(userID))
+                }
+            }
+        }
+    }
+
+    /// Toggle draining of our own streamed media file (same ordering guarantee
+    /// as `setUsers` for the source's removal).
+    func setLocalMediaEnabled(_ enabled: Bool) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let wasEnabled = self.localMediaEnabled
+            self.localMediaEnabled = enabled
+            if wasEnabled, enabled == false {
+                self.engine?.removeUser(TeamTalkConnectionController.localMediaEngineKey)
+            }
+        }
+    }
+
+    private func stopTimerLocked() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    private func tick() {
+        guard let instance, let engine else { return }
+        for userID in userIDs {
+            drain(instance: instance, engine: engine, userID: userID,
+                  streamType: STREAMTYPE_VOICE, engineKey: userID, profile: .network)
+            drain(instance: instance, engine: engine, userID: userID,
+                  streamType: STREAMTYPE_MEDIAFILE_AUDIO,
+                  engineKey: TeamTalkConnectionController.outputMediaSourceKey(userID), profile: .network)
+        }
+        if localMediaEnabled {
+            drain(instance: instance, engine: engine, userID: TT_LOCAL_USERID,
+                  streamType: STREAMTYPE_MEDIAFILE_AUDIO,
+                  engineKey: TeamTalkConnectionController.localMediaEngineKey, profile: .localMedia)
+        }
+    }
+
+    /// Acquire every queued block for one (user, stream) and hand the PCM to the
+    /// mix engine (which hops to its own serial queue).
+    private func drain(
+        instance: UnsafeMutableRawPointer,
+        engine: OutputAudioRenderEngine,
+        userID: Int32,
+        streamType: StreamType,
+        engineKey: Int32,
+        profile: OutputSourceBufferProfile
+    ) {
+        var drained = 0
+        while drained < maxBlocksPerStreamPerTick,
+              let block = TT_AcquireUserAudioBlock(instance, UInt32(streamType.rawValue), userID) {
+            drained += 1
+            let frames = Int(block.pointee.nSamples)
+            let channels = Int(block.pointee.nChannels)
+            let sampleRate = Int(block.pointee.nSampleRate)
+            if frames > 0, channels > 0, sampleRate > 0, let rawAudio = block.pointee.lpRawAudio {
+                // Copy the SDK PCM out before the block is released — the engine
+                // consumes it asynchronously on its own queue.
+                let samplePtr = rawAudio.assumingMemoryBound(to: Int16.self)
+                let pcm = Array(UnsafeBufferPointer(start: samplePtr, count: frames * channels))
+                engine.enqueueUser(
+                    engineKey,
+                    pcm: pcm,
+                    frames: frames, channels: channels, sampleRate: Double(sampleRate),
+                    profile: profile
+                )
+            }
+            TT_ReleaseUserAudioBlock(instance, block)
+        }
+    }
+}

--- a/App/ttaccessible/Services/OutputAudioRenderEngine.swift
+++ b/App/ttaccessible/Services/OutputAudioRenderEngine.swift
@@ -153,6 +153,16 @@ private final class PerUserMixSource {
     private let primeFrames: Int
     private let maxFrames: Int
     private var isPrimed = false
+    /// Largest single block (in frames) this source has received. The channel
+    /// codec's tx interval sets the block size (20–120+ ms), and the buffer's
+    /// ceiling must scale with it — see `append`.
+    private(set) var maxBlockFrames = 0
+
+    // Diagnostics (read/reset by the engine's periodic mix report).
+    var statBlocksIn = 0
+    var statUnderruns = 0
+    var statCeilingDrops = 0
+    var statDroppedFrames = 0
 
     init(channels: Int, primeFrames: Int, maxFrames: Int, settings: OutputUserMixSettings) {
         self.channels = max(1, channels)
@@ -164,15 +174,34 @@ private final class PerUserMixSource {
     var availableFrames: Int { (buffer.count - head) / channels }
 
     func append(_ samples: [Int16]) {
+        let blockFrames = samples.count / channels
+        if blockFrames > maxBlockFrames { maxBlockFrames = blockFrames }
+        statBlocksIn += 1
         buffer.append(contentsOf: samples)
-        // Catch-up: never let this source get more than `maxFrames` ahead of the
-        // device clock — that is pure added latency. If it does (the SDK delivered
-        // a burst, or the source clock ran fast), drop the oldest audio down to the
-        // `primeFrames` jitter target so latency stays bounded, instead of pinning
-        // at the cap forever (which caused ~225 ms backlog + constant dropouts).
+        // Catch-up ceiling: never let this source run more than one normal swing
+        // ahead of the device clock — beyond that is pure added latency, so drop
+        // down to a healthy level instead of pinning at the cap forever.
+        //
+        // The ceiling MUST scale with the observed block size: the level swings by
+        // a whole block per arrival, on top of the small cushion the source
+        // self-builds against delivery jitter (each early underrun shifts the
+        // consume phase later, so arrivals land "earlier" next time). A fixed
+        // ceiling tuned for 40 ms blocks sat exactly at that swing's peak for the
+        // 60 ms tx-interval channels used by busy community servers — every trip
+        // gutted the cushion, re-underrunning and re-tripping in a permanent chop
+        // cycle ("buffery, barely understandable"). Scaled headroom costs nothing
+        // for 20/40 ms channels (the configured max still applies as the floor)
+        // and steady-state latency is set by arrivals, not by the ceiling.
+        let margin = primeFrames / 2
+        let effectiveMax = max(maxFrames, primeFrames + 2 * maxBlockFrames + margin)
         let availFrames = (buffer.count - head) / channels
-        if availFrames > maxFrames {
-            head += (availFrames - primeFrames) * channels
+        if availFrames > effectiveMax {
+            // Keep prime + one block after a trip (not bare prime): enough to
+            // bridge to the next arrival without an immediate re-underrun.
+            let dropTo = primeFrames + maxBlockFrames
+            statCeilingDrops += 1
+            statDroppedFrames += availFrames - dropTo
+            head += (availFrames - dropTo) * channels
         }
         if head > 16_384 {
             buffer.removeFirst(head)
@@ -186,7 +215,11 @@ private final class PerUserMixSource {
     func prepareForMix() -> Bool {
         if settings.muted { return false }
         if isPrimed {
-            if availableFrames == 0 { isPrimed = false; return false }
+            if availableFrames == 0 {
+                isPrimed = false
+                statUnderruns += 1
+                return false
+            }
             return true
         }
         if availableFrames >= primeFrames { isPrimed = true; return true }
@@ -258,6 +291,10 @@ final class OutputAudioRenderEngine {
     /// Fine timer on `engineQueue` that drives `pumpMix` (replaces the 20 ms message-loop tick).
     private var mixTimer: DispatchSourceTimer?
     private let pumpIntervalMS = 5
+    /// Pump ticks since the last per-source diagnostics report (engineQueue only).
+    private var ticksSinceMixReport = 0
+    /// ~5 s at the 5 ms pump interval.
+    private let mixReportEveryTicks = 1000
 
     init() {
         gainCell.initialize(to: 1)
@@ -599,6 +636,40 @@ final class OutputAudioRenderEngine {
 
         if primedCell.pointee == 0, ring.fillCount() / mixChannels >= targetFillFrames {
             primedCell.pointee = 1
+        }
+
+        reportMixHealthIfDue()
+    }
+
+    /// Every ~5 s, log per-source stats — but only when a source actually
+    /// underran or hit its catch-up ceiling, so a healthy session stays silent.
+    /// This is what distinguishes "blocks arrive gappy" (delivery/network/server)
+    /// from "blocks arrive fine but we mishandle them" (buffer tuning) in the field.
+    private func reportMixHealthIfDue() {
+        ticksSinceMixReport += 1
+        guard ticksSinceMixReport >= mixReportEveryTicks else { return }
+        ticksSinceMixReport = 0
+        guard deviceSampleRate > 0, userSources.isEmpty == false else { return }
+
+        let msPerFrame = 1000.0 / deviceSampleRate
+        var troubled: [String] = []
+        for (key, src) in userSources {
+            if src.statUnderruns > 0 || src.statCeilingDrops > 0 {
+                troubled.append(String(
+                    format: "key=%d blocks=%d maxBlock=%.0fms avail=%.0fms underruns=%d drops=%d dropped=%.0fms",
+                    key, src.statBlocksIn, Double(src.maxBlockFrames) * msPerFrame,
+                    Double(src.availableFrames) * msPerFrame,
+                    src.statUnderruns, src.statCeilingDrops,
+                    Double(src.statDroppedFrames) * msPerFrame
+                ))
+            }
+            src.statBlocksIn = 0
+            src.statUnderruns = 0
+            src.statCeilingDrops = 0
+            src.statDroppedFrames = 0
+        }
+        if troubled.isEmpty == false {
+            AudioLogger.log("mix diag: %d sources, troubled: %@", userSources.count, troubled.joined(separator: " | "))
         }
     }
 

--- a/App/ttaccessible/Services/OutputAudioRenderEngine.swift
+++ b/App/ttaccessible/Services/OutputAudioRenderEngine.swift
@@ -226,17 +226,19 @@ private final class PerUserMixSource {
         return false
     }
 
-    /// Pop the next frame as (left, right) source samples (mono is duplicated).
-    /// Returns false if empty.
-    func popFrameLR() -> (Int16, Int16)? {
-        guard buffer.count - head >= channels else { return nil }
-        let base = head
-        head += channels
-        if channels == 1 {
-            let s = buffer[base]
-            return (s, s)
+    /// Accumulate up to `frames` frames into the stereo Int32 accumulator with
+    /// the given per-side gains. The per-sample work happens in the C hot loop
+    /// (`ttac_mix_add`) so it stays real-time-fast even in unoptimized builds.
+    /// Returns the number of frames consumed (short when the source runs dry).
+    func mixInto(_ acc: UnsafeMutablePointer<Int32>, frames: Int, leftGain: Float, rightGain: Float) -> Int {
+        let n = min(frames, availableFrames)
+        guard n > 0 else { return 0 }
+        buffer.withUnsafeBufferPointer { buf in
+            guard let base = buf.baseAddress else { return }
+            ttac_mix_add(acc, base + head, Int32(n), Int32(channels), leftGain, rightGain)
         }
-        return (buffer[base], buffer[base + 1])
+        head += n * channels
+        return n
     }
 }
 
@@ -266,6 +268,8 @@ final class OutputAudioRenderEngine {
     private var userSources: [Int32: PerUserMixSource] = [:]
     private var defaultUserSettings: [Int32: OutputUserMixSettings] = [:]
     private var mixScratch: [Int16] = []
+    /// Stereo Int32 accumulator the C mix loop sums sources into.
+    private var accScratch: [Int32] = []
     private var perUserPrimeFrames: Int = 0   // per-user jitter-buffer target
     private var perUserMaxFrames: Int = 0      // per-user catch-up ceiling
 
@@ -279,7 +283,10 @@ final class OutputAudioRenderEngine {
     private var rtDeviceChannels = 0
     private var rtPull: UnsafeMutablePointer<Int16>?
     private var rtPullCapacity = 0
-    private var rtPlanePtrs: [UnsafeMutablePointer<Float>?] = []
+    /// C array of plane pointers handed to `ttac_render_planes` (no Swift
+    /// array machinery on the render thread).
+    private var rtPlanesC: UnsafeMutablePointer<UnsafeMutablePointer<Float>?>?
+    private var rtPlanesCapacity = 0
     private var currentGain: Float = 1
     private var gainSmoothCoeff: Float = 0.01
 
@@ -427,7 +434,10 @@ final class OutputAudioRenderEngine {
         self.rtDeviceChannels = devChannels
         self.rtPull = pull
         self.rtPullCapacity = pullCapacity
-        self.rtPlanePtrs = [UnsafeMutablePointer<Float>?](repeating: nil, count: max(devChannels, 1))
+        rtPlanesC?.deallocate()
+        self.rtPlanesCapacity = max(devChannels, 1)
+        self.rtPlanesC = UnsafeMutablePointer<UnsafeMutablePointer<Float>?>.allocate(capacity: rtPlanesCapacity)
+        self.rtPlanesC?.initialize(repeating: nil, count: rtPlanesCapacity)
         self.currentGain = gainCell.pointee
         self.gainSmoothCoeff = Float(1.0 - exp(-1.0 / (0.008 * devRate)))
         self.underflowCount = 0
@@ -474,7 +484,7 @@ final class OutputAudioRenderEngine {
         rtPull?.deallocate(); rtPull = nil; rtPullCapacity = 0
         ring?.free(); ring = nil
         rtDeviceChannels = 0; deviceChannels = 0; deviceSampleRate = 0
-        rtPlanePtrs = []
+        rtPlanesC?.deallocate(); rtPlanesC = nil; rtPlanesCapacity = 0
     }
 
     func stop() {
@@ -491,7 +501,7 @@ final class OutputAudioRenderEngine {
 
         let drained = underflowCount
         rtPull?.deallocate(); rtPull = nil; rtPullCapacity = 0
-        rtPlanePtrs = []
+        rtPlanesC?.deallocate(); rtPlanesC = nil; rtPlanesCapacity = 0
         ring?.free(); ring = nil
         userSources.removeAll()
         deviceChannels = 0; deviceSampleRate = 0; rtDeviceChannels = 0
@@ -613,25 +623,26 @@ final class OutputAudioRenderEngine {
         if mixScratch.count < needed {
             mixScratch = [Int16](repeating: 0, count: needed)
         }
+        if accScratch.count < needed {
+            accScratch = [Int32](repeating: 0, count: needed)
+        }
 
         // Only mix sources that are primed (have buffered past their jitter target);
-        // this gate also drops a source mid-tick once it underruns.
+        // this gate also drops a source mid-tick once it underruns. The per-sample
+        // summing/clamping runs in the C hot loops so it holds up in -Onone builds.
         let active = userSources.values.filter { $0.prepareForMix() }
-        mixScratch.withUnsafeMutableBufferPointer { out in
-            guard let outBase = out.baseAddress else { return }
-            for f in 0..<produce {
-                var left = 0
-                var right = 0
-                for src in active {
-                    guard let (sl, sr) = src.popFrameLR() else { continue }
-                    let (lg, rg) = Self.panGains(volume: src.settings.volume, pan: src.settings.pan)
-                    left += Int(Float(sl) * lg)
-                    right += Int(Float(sr) * rg)
-                }
-                outBase[f * 2] = Int16(clamping: left)
-                outBase[f * 2 + 1] = Int16(clamping: right)
+        accScratch.withUnsafeMutableBufferPointer { accBuf in
+            guard let acc = accBuf.baseAddress else { return }
+            ttac_mix_clear(acc, Int32(needed))
+            for src in active {
+                let (lg, rg) = Self.panGains(volume: src.settings.volume, pan: src.settings.pan)
+                _ = src.mixInto(acc, frames: produce, leftGain: lg, rightGain: rg)
             }
-            ring.write(outBase, count: needed)
+            mixScratch.withUnsafeMutableBufferPointer { out in
+                guard let outBase = out.baseAddress else { return }
+                ttac_mix_clamp(outBase, acc, Int32(needed))
+                ring.write(outBase, count: needed)
+            }
         }
 
         if primedCell.pointee == 0, ring.fillCount() / mixChannels >= targetFillFrames {
@@ -692,16 +703,22 @@ final class OutputAudioRenderEngine {
     ) -> OSStatus {
         guard let ioData else { return noErr }
         // Acquire the RT render state published by startImpl's release fence before
-        // reading rtDeviceChannels / rtPlanePtrs / rtPullCapacity / rtPull / currentGain.
+        // reading rtDeviceChannels / rtPlanesC / rtPullCapacity / rtPull / currentGain.
         ttac_atomic_fence_acquire()
         let abl = UnsafeMutableAudioBufferListPointer(ioData)
         let devCh = rtDeviceChannels
         let frameCount = Int(inNumberFrames)
         let srcCh = mixChannels
-        guard devCh > 0, frameCount > 0, devCh <= rtPlanePtrs.count else { return noErr }
+        guard devCh > 0, frameCount > 0, devCh <= rtPlanesCapacity, let planes = rtPlanesC else { return noErr }
 
-        for ch in 0..<devCh {
+        var allPlanesValid = true
+        var ch = 0
+        while ch < devCh {
             abl[ch].mDataByteSize = UInt32(frameCount * MemoryLayout<Float>.size)
+            let p = abl[ch].mData?.assumingMemoryBound(to: Float.self)
+            planes[ch] = p
+            if p == nil { allPlanesValid = false }
+            ch += 1
         }
 
         let ready = primedCell.pointee != 0
@@ -709,55 +726,27 @@ final class OutputAudioRenderEngine {
             && ring != nil
             && rtPull != nil
 
-        let target: Float = (muteCell.pointee != 0) ? 0 : gainCell.pointee
-        let coeff = gainSmoothCoeff
-        let invScale: Float = 1.0 / 32_768.0
-
-        rtPlanePtrs.withUnsafeMutableBufferPointer { planesBuf in
-            guard let planes = planesBuf.baseAddress else { return }
-            var allPlanesValid = true
-            for ch in 0..<devCh {
-                let p = abl[ch].mData?.assumingMemoryBound(to: Float.self)
-                planes[ch] = p
-                if p == nil { allPlanesValid = false }
+        guard ready, allPlanesValid, let ring, let pull = rtPull else {
+            ch = 0
+            while ch < devCh {
+                if let plane = planes[ch] { plane.update(repeating: 0, count: frameCount) }
+                ch += 1
             }
-
-            guard ready, allPlanesValid, let ring, let pull = rtPull else {
-                for ch in 0..<devCh {
-                    if let plane = planes[ch] { plane.update(repeating: 0, count: frameCount) }
-                }
-                return
-            }
-
-            let pulled = ring.read(into: pull, maxSamples: frameCount * srcCh)
-            let framesAvailable = pulled / srcCh
-            if framesAvailable < frameCount { underflowCount += 1 }
-
-            var g = currentGain
-            for f in 0..<frameCount {
-                g += (target - g) * coeff
-                if f < framesAvailable {
-                    let base = f * srcCh   // stereo source: [L, R]
-                    for ch in 0..<devCh {
-                        guard let plane = planes[ch] else { continue }
-                        let sample: Int16
-                        if devCh == 1 {
-                            sample = Int16(clamping: (Int(pull[base]) + Int(pull[base + 1])) / 2)
-                        } else if ch <= 1 {
-                            sample = pull[base + ch]
-                        } else {
-                            sample = 0   // extra device channels (>2) get silence
-                        }
-                        plane[f] = Float(sample) * invScale * g
-                    }
-                } else {
-                    for ch in 0..<devCh {
-                        if let plane = planes[ch] { plane[f] = 0 }
-                    }
-                }
-            }
-            currentGain = g
+            return noErr
         }
+
+        let pulled = ring.read(into: pull, maxSamples: frameCount * srcCh)
+        let framesAvailable = pulled / srcCh
+        if framesAvailable < frameCount { underflowCount += 1 }
+
+        // Per-frame conversion + gain smoothing in the C hot loop (RT-safe in
+        // every build configuration; -Onone Swift measurably missed deadlines).
+        let target: Float = (muteCell.pointee != 0) ? 0 : gainCell.pointee
+        currentGain = ttac_render_planes(
+            planes, Int32(devCh), pull,
+            Int32(framesAvailable), Int32(frameCount),
+            currentGain, target, gainSmoothCoeff
+        )
 
         return noErr
     }

--- a/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController+Audio.swift
@@ -592,6 +592,9 @@ extension TeamTalkConnectionController {
         outputAudioReady = true
         appliedOutputPreference = preferencesStore.preferences.preferredOutputDevice
         startOutputRenderEngineLocked()
+        // Start the dedicated block drainer BEFORE enabling events, so the user
+        // set pushed by the refresh below lands on a running pump.
+        audioBlockPump.start(instance: instance, engine: outputRenderEngine)
         // Enable per-user audio block events for whoever is already in our channel.
         refreshPerUserAudioEventsLocked(instance: instance)
         // Re-arm our own media subscription if a stream is already active (e.g. the
@@ -638,16 +641,19 @@ extension TeamTalkConnectionController {
     }
 
     /// Separate mixer key for a user's media-file stream (kept distinct from their
-    /// voice stream).
-    func outputMediaSourceKey(_ userID: Int32) -> Int32 { userID | 0x4000_0000 }
+    /// voice stream). Static so AudioBlockPump shares the same mapping.
+    nonisolated static func outputMediaSourceKey(_ userID: Int32) -> Int32 { userID | 0x4000_0000 }
+    func outputMediaSourceKey(_ userID: Int32) -> Int32 { Self.outputMediaSourceKey(userID) }
 
     /// Reserved mixer key for the local "hear myself" monitor (negative, so it
     /// never collides with real user IDs or media keys, both positive).
     var localMonitorEngineKey: Int32 { -1 }
 
     /// Reserved mixer key for our OWN streamed media file, so the local user hears
-    /// what they broadcast. Negative for the same no-collision reason.
-    var localMediaEngineKey: Int32 { -2 }
+    /// what they broadcast. Negative for the same no-collision reason. Static so
+    /// AudioBlockPump shares the same key.
+    nonisolated static let localMediaEngineKey: Int32 = -2
+    var localMediaEngineKey: Int32 { Self.localMediaEngineKey }
 
     /// Subscribe (or unsubscribe) to our OWN media-file stream so the local user
     /// hears the media they broadcast into the channel. The SDK delivers this on
@@ -662,10 +668,12 @@ extension TeamTalkConnectionController {
             AudioLogger.log("local media: subscribed to own media stream for local playback")
         } else {
             TT_EnableAudioBlockEvent(instance, TT_LOCAL_USERID, media, 0)
-            outputRenderEngine.removeUser(localMediaEngineKey)
             AudioLogger.log("local media: unsubscribed from own media stream")
         }
         localMediaAudioEnabled = shouldEnable
+        // The pump drains this stream and removes its mix source on disable
+        // (ordered after its final enqueue).
+        audioBlockPump.setLocalMediaEnabled(shouldEnable)
     }
 
     /// Reconcile per-user audio block events with the users currently in our
@@ -698,10 +706,11 @@ extension TeamTalkConnectionController {
         for userID in toDisable {
             TT_EnableAudioBlockEvent(instance, userID, voice, 0)
             TT_EnableAudioBlockEvent(instance, userID, media, 0)
-            outputRenderEngine.removeUser(userID)
-            outputRenderEngine.removeUser(outputMediaSourceKey(userID))
         }
         perUserAudioEnabled = desired
+        // The pump removes departed users' mix sources itself, ordered after its
+        // final block enqueue for them (so no ghost source reappears).
+        audioBlockPump.setUsers(desired)
     }
 
     func channelUsersLocked(instance: UnsafeMutableRawPointer, channelID: Int32) -> [User] {
@@ -712,56 +721,30 @@ extension TeamTalkConnectionController {
         return Array(users.prefix(Int(count)))
     }
 
-    /// Dispatch a CLIENTEVENT_USER_AUDIOBLOCK. A remote user's voice/media goes to
-    /// the mixer for playback; the muxed stream (only enabled as the pre-14.2 AEC
-    /// fallback) feeds the echo canceller's far-end reference.
+    /// Dispatch a CLIENTEVENT_USER_AUDIOBLOCK. Only the muxed stream (the
+    /// pre-14.2 AEC reference fallback, whose consumer is confined to this
+    /// queue) is acquired here. Per-user voice/media and our own media stream
+    /// are drained by AudioBlockPump on its dedicated timer — acquiring them on
+    /// this queue starved every mix source at once whenever a tick ran long
+    /// (heavy publish in a crowded channel), making everyone sound choppy.
     func handleAudioBlockLocked(instance: UnsafeMutableRawPointer, source: Int32) {
-        if source == TT_MUXED_USERID {
-            guard let block = TT_AcquireUserAudioBlock(instance, UInt32(STREAMTYPE_VOICE.rawValue), TT_MUXED_USERID) else { return }
-            if speakerTapCaptureStorage == nil,
-               let aec = advancedMicrophoneEngine.echoCanceller,
-               let rawAudio = block.pointee.lpRawAudio {
-                let int16Ptr = rawAudio.assumingMemoryBound(to: Int16.self)
-                aec.feedReference(int16Ptr, count: Int(block.pointee.nSamples), channels: Int(block.pointee.nChannels), sampleRate: Int(block.pointee.nSampleRate))
-            }
-            TT_ReleaseUserAudioBlock(instance, block)
-            return
+        guard source == TT_MUXED_USERID else { return }
+        guard let block = TT_AcquireUserAudioBlock(instance, UInt32(STREAMTYPE_VOICE.rawValue), TT_MUXED_USERID) else { return }
+        if speakerTapCaptureStorage == nil,
+           let aec = advancedMicrophoneEngine.echoCanceller,
+           let rawAudio = block.pointee.lpRawAudio {
+            let int16Ptr = rawAudio.assumingMemoryBound(to: Int16.self)
+            aec.feedReference(int16Ptr, count: Int(block.pointee.nSamples), channels: Int(block.pointee.nChannels), sampleRate: Int(block.pointee.nSampleRate))
         }
-
-        if source == TT_LOCAL_USERID {
-            // Our own streamed media file, delivered so we hear what we broadcast.
-            // It's burstier than network audio, so it uses the deeper localMedia buffer.
-            enqueueUserAudioBlockLocked(instance: instance, userID: TT_LOCAL_USERID, streamType: STREAMTYPE_MEDIAFILE_AUDIO, engineKey: localMediaEngineKey, profile: .localMedia)
-            return
-        }
-
-        let myUserID = TT_GetMyUserID(instance)
-        guard source > 0, source != myUserID else { return }
-        enqueueUserAudioBlockLocked(instance: instance, userID: source, streamType: STREAMTYPE_VOICE, engineKey: source)
-        enqueueUserAudioBlockLocked(instance: instance, userID: source, streamType: STREAMTYPE_MEDIAFILE_AUDIO, engineKey: outputMediaSourceKey(source))
-    }
-
-    private func enqueueUserAudioBlockLocked(instance: UnsafeMutableRawPointer, userID: Int32, streamType: StreamType, engineKey: Int32, profile: OutputSourceBufferProfile = .network) {
-        guard let block = TT_AcquireUserAudioBlock(instance, UInt32(streamType.rawValue), userID) else { return }
-        defer { TT_ReleaseUserAudioBlock(instance, block) }
-        let frames = Int(block.pointee.nSamples)
-        let channels = Int(block.pointee.nChannels)
-        let sampleRate = Int(block.pointee.nSampleRate)
-        guard frames > 0, channels > 0, sampleRate > 0, let rawAudio = block.pointee.lpRawAudio else { return }
-        // Copy the SDK PCM out before the block is released — the engine consumes it
-        // asynchronously on its own queue.
-        let samplePtr = rawAudio.assumingMemoryBound(to: Int16.self)
-        let pcm = Array(UnsafeBufferPointer(start: samplePtr, count: frames * channels))
-        outputRenderEngine.enqueueUser(
-            engineKey,
-            pcm: pcm,
-            frames: frames, channels: channels, sampleRate: Double(sampleRate),
-            profile: profile
-        )
+        TT_ReleaseUserAudioBlock(instance, block)
     }
 
     /// Tear down the output render path (engine + all per-user / muxed events).
     func teardownOutputRenderLocked(instance: UnsafeMutableRawPointer?) {
+        // Stop the block pump FIRST (synchronous): after this no SDK calls come
+        // from its queue, so the events below can be disabled and the instance
+        // torn down without racing an in-flight acquire.
+        audioBlockPump.stop()
         outputRenderEngine.stop()
         if let instance {
             let voice = UInt32(STREAMTYPE_VOICE.rawValue)

--- a/App/ttaccessible/Services/TeamTalkConnectionController.swift
+++ b/App/ttaccessible/Services/TeamTalkConnectionController.swift
@@ -217,6 +217,10 @@ final class TeamTalkConnectionController {
     /// and render it ourselves, so switching the output device never calls the
     /// SDK's deadlock-prone TT_CloseSoundOutputDevice. See OutputAudioRenderEngine.
     let outputRenderEngine = OutputAudioRenderEngine()
+    /// Dedicated drainer for per-user audio blocks, decoupled from the message
+    /// loop so a slow tick (heavy publish in a crowded channel) can never starve
+    /// the mix sources. See AudioBlockPump.
+    let audioBlockPump = AudioBlockPump()
     /// Remote user IDs we currently have per-user audio block events enabled for
     /// (reconciled with channel membership; the local user is never included).
     var perUserAudioEnabled: Set<Int32> = []


### PR DESCRIPTION
Channels configured with large OPUS tx intervals (60–120 ms — common on busy community servers to save bandwidth) played back badly choppy, to the point of being hard to understand, while 20/40 ms channels were fine. Three commits, each independently useful:

**1. Scale the per-user buffer ceiling to the channel's packet size** (the actual fix)

Each mix source's catch-up ceiling was a fixed 120 ms, tuned for ~40 ms packets. A source's buffer level swings by one whole packet per arrival on top of the small cushion it self-builds against delivery jitter; with 60 ms packets that swing peaks right at the ceiling, so nearly every arrival tripped it, cut the buffer back to the 25 ms prime (discarding most of a packet each time), the source audibly underran, rebuilt its cushion, and tripped again — a permanent chop cycle. Simulating the exact state machine: with 120 ms packets the old constants discard ~16 seconds of audio per minute.

The ceiling now scales with the largest packet the source has actually received (prime + 2×packet + margin, floored at the old 120 ms), and a trip drops to prime + one packet instead of bare prime. 20/40 ms channels behave identically to before; steady-state latency is set by arrival timing, not the ceiling, so nothing gets slower.

**2. Drain audio blocks on a dedicated pump**

Per-user audio blocks were acquired inside the 20 ms message-loop drain, on the same serial queue that rebuilds the channel tree, appends history and processes state updates — work that grows with channel population. One slow tick starved every mix source at once. `AudioBlockPump` acquires per-user voice/media (and own-media) blocks on its own 10 ms user-interactive timer queue, so delivery is immune to message-loop congestion. The muxed stream (pre-14.2 AEC reference fallback) stays on the message loop since its consumer is confined there. Departed users' sources are removed by the pump itself, ordered after its final enqueue, so a leaving user can't resurrect a ghost source.

**3. Move the per-sample mix/render loops to C**

Debug (-Onone) builds audibly glitched under real load: sampling the live process showed the per-frame Swift loops in `pumpMix` and the render callback dominated by range iterators, tuple returns, generic numeric initializers and witness-table lookups — 40% CPU and missed HAL deadlines on a multi-channel interface, while every internal counter stayed clean (the math was right; the callback was late). The per-sample work now lives in `AudioRTSupport.h` as plain C, which compiles to tight loops in every build configuration. Semantics are bit-identical (truncation, clamping, mono downmix, gain smoothing through silent tails), verified by a standalone harness at -O0 and -O2; worst-case throughput at -O0 is ~0.12% of the real-time budget (1 s of 24-channel render + 10 sources in ~1.2 ms).

Also adds a quiet mix-health diagnostic: every ~5 s, only if a source underran or tripped its ceiling, one `mix diag:` log line reports per-source packet size/level/underruns/drops — it distinguishes gappy delivery from buffer mishandling in field reports, and healthy sessions log nothing.

Verified live on a 60 ms community server channel: previously barely understandable, now clean (and the diagnostic line confirms zero underruns/drops).