### PR TITLE
Guarantee the PortAudio probe patch is applied at build time

### DIFF
--- a/App/ttaccessible.xcodeproj/project.pbxproj
+++ b/App/ttaccessible.xcodeproj/project.pbxproj
@@ -38,6 +38,24 @@
 		};
 /* End PBXCopyFilesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		94A4A5FA3B941A8E00C01234 /* Patch TeamTalk SDK (PortAudio probe) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Patch TeamTalk SDK (PortAudio probe)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Ensure the vendored TeamTalk dylib has PortAudio's slow startup device probe\n# patched out before it is linked and embedded. libTeamTalk5.dylib is a gitignored\n# download, so a build machine with an unpatched cached copy would otherwise ship\n# the ~13s-slow-connect build. The patcher is idempotent and fails loudly, so it is\n# safe to run on every build. See scripts/patch-sdk-portaudio.py for the rationale.\nset -e\nDYLIB=\"${SRCROOT}/../Vendor/TeamTalk/libTeamTalk5.dylib\"\nif [ ! -f \"$DYLIB\" ]; then\n  echo \"error: $DYLIB not found - run scripts/download-sdk.sh first\" >&2\n  exit 1\nfi\npython3 \"${SRCROOT}/../scripts/patch-sdk-portaudio.py\" \"$DYLIB\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXFileReference section */
 		941A588C2FE8718F00C08287 /* ttaccessibleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ttaccessibleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		943281C62F68C35A00682D6B /* ttaccessible.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ttaccessible.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,6 +156,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 943281D12F68C35A00682D6B /* Build configuration list for PBXNativeTarget "ttaccessible" */;
 			buildPhases = (
+				94A4A5FA3B941A8E00C01234 /* Patch TeamTalk SDK (PortAudio probe) */,
 				943281C22F68C35A00682D6B /* Sources */,
 				943281C32F68C35A00682D6B /* Frameworks */,
 				94A4A5F83B941A8E00C01234 /* Embed TeamTalk */,

--- a/scripts/download-sdk.sh
+++ b/scripts/download-sdk.sh
@@ -33,7 +33,12 @@ if [ -f "$VENDOR_DIR/libTeamTalk5.dylib" ]; then
     echo "libTeamTalk5.dylib already exists in Vendor/TeamTalk/."
     read -p "Overwrite? [y/N] " answer
     if [[ ! "$answer" =~ ^[Yy]$ ]]; then
-        echo "Aborted."
+        # Don't re-download, but STILL make sure the existing dylib is patched.
+        # The patch must never be coupled to a fresh download: a cached, unpatched
+        # copy is exactly how a ~13 s-slow-connect build ships. The patcher is
+        # idempotent, so this is a no-op when the dylib is already patched.
+        echo "Keeping existing dylib. Ensuring PortAudio probe is patched..."
+        python3 "$(dirname "$0")/patch-sdk-portaudio.py" "$VENDOR_DIR/libTeamTalk5.dylib"
         exit 0
     fi
 fi


### PR DESCRIPTION
The `IsFormatSupported` patch that removes PortAudio's ~13 s startup device probe (added in beta.7) is only applied inside `download-sdk.sh`, and only on a *fresh* download.

`libTeamTalk5.dylib` is a gitignored artifact, so a build machine that already has an unpatched cached copy (downloaded before the patch existed) never gets it re-applied — nothing at build time ensures it — and ships the slow-connect build. The distributed **v1.7.0-beta.9** binary embeds an unpatched dylib for exactly this reason: connecting to a channel takes ~13 s on larger device setups instead of being near-instant.

**Fix**
- Add a `Patch TeamTalk SDK` run-script build phase that runs the existing idempotent, fail-loud patcher on the vendored dylib before it is linked/embedded — so no build can ship unpatched regardless of how the dylib got onto the machine.
- Decouple the patch in `download-sdk.sh` so re-running it patches an existing dylib instead of skipping entirely when the user declines the re-download.

No product code changes; the dylib stays out of the repo.

**Verified:** built from a deliberately-unpatched vendored dylib and confirmed the embedded dylib in the resulting `.app` comes out patched. Also confirmed patching a distributed beta.9 in place makes connect near-instant.