### PR TITLE
Global mic-toggle hotkey: work while ttaccessible is focused, and use one chord everywhere

### DIFF
--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -241,11 +241,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // stays muted forever in push-to-talk mode.
         pushToTalkMonitor.onPress = { [weak self] in self?.handlePushToTalkPress() }
         pushToTalkMonitor.onRelease = { [weak self] in self?.handlePushToTalkRelease() }
-        // The global ⌘⇧A tap fires only while another app is focused (the menu
-        // shortcut covers the focused case), so it mirrors the menu action —
-        // without restoring/focusing our window, which would steal focus.
+        // Mirrors the menu action without restoring/focusing our window, which
+        // would steal focus. The tap defers to the menu for a chord the menu
+        // carries (⌘⇧A by default), and answers any other binding itself,
+        // focused or not. Requires a channel for the same reason the menu item
+        // is disabled without one: transmission has no meaning outside a
+        // channel, and the SDK path would fail with "not in a channel" and pop
+        // an alert over whatever app the user is actually in.
         muteHotkeyMonitor.onPress = { [weak self] in
-            guard let self, self.menuState.mode == .connectedServer else { return }
+            guard let self,
+                  self.menuState.mode == .connectedServer,
+                  self.menuState.isInChannel else { return }
             self.connectedServerViewController?.performToggleMicrophoneShortcut(announceStatus: true)
         }
 
@@ -301,7 +307,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             muteHotkeyMonitor.configure(
                 binding: prefs.muteHotkeyBinding ?? HotkeyBinding.defaultMuteHotkey(),
                 scope: .global,
-                globalOnlyWhenInactive: true,
+                deferToMainMenuWhenActive: true,
                 wantsReleaseEvents: false
             )
         } else {

--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -219,6 +219,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// owns that binding in every focus state, which is the same one-chord
     /// contract by a different route.
     ///
+    /// A binding that types (a bare or ⇧-only printable key) is withheld the same
+    /// way: an item carrying it would answer the key before a focused chat field
+    /// did, toggling the mic mid-sentence. The tap declines it while a field is
+    /// focused and answers it otherwise, so the chord still works everywhere it
+    /// isn't being typed.
+    ///
     /// Takes the preferences rather than reading the store: this also runs from
     /// the `$preferences` sink, where `@Published` fires in willSet and the
     /// stored property still holds the OLD value.
@@ -231,7 +237,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         let binding = preferences.muteHotkeyBinding ?? HotkeyBinding.defaultMuteHotkey()
-        if let equivalent = binding.menuKeyEquivalent {
+        if let equivalent = binding.safeMenuKeyEquivalent {
             item.keyEquivalent = equivalent.characters
             item.keyEquivalentModifierMask = equivalent.modifiers
         } else {

--- a/App/ttaccessible/AppDelegate.swift
+++ b/App/ttaccessible/AppDelegate.swift
@@ -205,6 +205,57 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             $0.submenu?.title == title || $0.title == title
         }) else { return }
         item.isHidden = menuState.mode != .connectedServer
+        applyMuteMenuShortcut(with: preferencesStore.preferences)
+    }
+
+    /// Keeps the User ▸ Microphone item's key equivalent equal to the global
+    /// mute binding, so one chord toggles the mic whether or not ttaccessible is
+    /// focused — the menu answers it here, the tap answers it everywhere else.
+    /// Declared in SwiftUI as ⌘⇧A, which is the right default and stays put
+    /// while the hotkey is app-local; a global binding overrides it.
+    ///
+    /// A chord with no key-equivalent form (a pure-modifier chord) leaves the
+    /// item without a shortcut rather than stranding ⌘⇧A on it — the tap then
+    /// owns that binding in every focus state, which is the same one-chord
+    /// contract by a different route.
+    ///
+    /// Takes the preferences rather than reading the store: this also runs from
+    /// the `$preferences` sink, where `@Published` fires in willSet and the
+    /// stored property still holds the OLD value.
+    private func applyMuteMenuShortcut(with preferences: AppPreferences) {
+        let title = L10n.text("shortcuts.microphone")
+        guard let item = findMainMenuItem(titled: title) else { return }
+        guard preferences.muteHotkeyGlobal else {
+            item.keyEquivalent = Self.defaultMuteMenuKeyEquivalent.characters
+            item.keyEquivalentModifierMask = Self.defaultMuteMenuKeyEquivalent.modifiers
+            return
+        }
+        let binding = preferences.muteHotkeyBinding ?? HotkeyBinding.defaultMuteHotkey()
+        if let equivalent = binding.menuKeyEquivalent {
+            item.keyEquivalent = equivalent.characters
+            item.keyEquivalentModifierMask = equivalent.modifiers
+        } else {
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+        }
+    }
+
+    /// ⌘⇧ + whatever key types "a" on the current layout, matching what the
+    /// SwiftUI declaration means (key codes are positional; the character is not).
+    private static var defaultMuteMenuKeyEquivalent: (characters: String, modifiers: NSEvent.ModifierFlags) {
+        HotkeyBinding.defaultMuteHotkey().menuKeyEquivalent ?? ("a", [.command, .shift])
+    }
+
+    private func findMainMenuItem(titled title: String) -> NSMenuItem? {
+        func search(_ menu: NSMenu) -> NSMenuItem? {
+            for item in menu.items {
+                if item.title == title { return item }
+                if let submenu = item.submenu, let found = search(submenu) { return found }
+            }
+            return nil
+        }
+        guard let mainMenu = NSApp.mainMenu else { return nil }
+        return search(mainMenu)
     }
 
     private func syncNicknamePreference() {
@@ -286,6 +337,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             mode: prefs.microphoneMode,
             pushToTalkKeyConfigured: prefs.pushToTalkKey?.isValid ?? false
         )
+
+        // The focused case is the menu's, so it has to track the same binding.
+        applyMuteMenuShortcut(with: prefs)
 
         let pttActive = prefs.microphoneMode == .pushToTalk || prefs.microphoneMode == .both
         if pttActive, let key = prefs.pushToTalkKey, key.isValid {

--- a/App/ttaccessible/Models/HotkeyBinding.swift
+++ b/App/ttaccessible/Models/HotkeyBinding.swift
@@ -100,6 +100,9 @@ struct HotkeyBinding: Codable, Equatable {
         118: NSF4FunctionKey, 96: NSF5FunctionKey, 97: NSF6FunctionKey,
         98: NSF7FunctionKey, 100: NSF8FunctionKey, 101: NSF9FunctionKey,
         109: NSF10FunctionKey, 103: NSF11FunctionKey, 111: NSF12FunctionKey,
+        105: NSF13FunctionKey, 107: NSF14FunctionKey, 113: NSF15FunctionKey,
+        106: NSF16FunctionKey, 64: NSF17FunctionKey, 79: NSF18FunctionKey,
+        80: NSF19FunctionKey, 90: NSF20FunctionKey,
         123: NSLeftArrowFunctionKey, 124: NSRightArrowFunctionKey,
         125: NSDownArrowFunctionKey, 126: NSUpArrowFunctionKey,
         115: NSHomeFunctionKey, 119: NSEndFunctionKey,
@@ -159,7 +162,12 @@ struct HotkeyBinding: Codable, Equatable {
         116: "Page Up",
         121: "Page Down",
         122: "F1", 120: "F2", 99: "F3", 118: "F4", 96: "F5", 97: "F6",
-        98: "F7", 100: "F8", 101: "F9", 109: "F10", 103: "F11", 111: "F12"
+        98: "F7", 100: "F8", 101: "F9", 109: "F10", 103: "F11", 111: "F12",
+        // F13–F20 type nothing and carry no system function, which makes them
+        // the one genuinely safe global binding — they were showing as
+        // "Key 105" because the table stopped at F12.
+        105: "F13", 107: "F14", 113: "F15", 106: "F16",
+        64: "F17", 79: "F18", 80: "F19", 90: "F20"
     ]
 
     private static func keyLabel(for event: NSEvent) -> String {

--- a/App/ttaccessible/Models/HotkeyBinding.swift
+++ b/App/ttaccessible/Models/HotkeyBinding.swift
@@ -89,6 +89,57 @@ struct HotkeyBinding: Codable, Equatable {
         return symbols + keyLabel
     }
 
+    // MARK: - Menu key equivalents
+
+    /// Virtual key codes AppKit expresses as a function-key unicode scalar
+    /// rather than a typed character. Anything a layout can type is resolved
+    /// through `KeyCodeResolver` instead, so this covers only the keys that
+    /// type nothing.
+    private static let menuFunctionKeyScalars: [Int: Int] = [
+        122: NSF1FunctionKey, 120: NSF2FunctionKey, 99: NSF3FunctionKey,
+        118: NSF4FunctionKey, 96: NSF5FunctionKey, 97: NSF6FunctionKey,
+        98: NSF7FunctionKey, 100: NSF8FunctionKey, 101: NSF9FunctionKey,
+        109: NSF10FunctionKey, 103: NSF11FunctionKey, 111: NSF12FunctionKey,
+        123: NSLeftArrowFunctionKey, 124: NSRightArrowFunctionKey,
+        125: NSDownArrowFunctionKey, 126: NSUpArrowFunctionKey,
+        115: NSHomeFunctionKey, 119: NSEndFunctionKey,
+        116: NSPageUpFunctionKey, 121: NSPageDownFunctionKey,
+        117: NSDeleteFunctionKey
+    ]
+
+    /// Keys AppKit matches by a plain control character.
+    private static let menuControlCharacters: [Int: String] = [
+        49: " ",         // Space
+        48: "\t",        // Tab
+        36: "\r",        // Return
+        76: "\u{3}",     // Enter
+        53: "\u{1B}",    // Esc
+        51: "\u{8}"      // Delete
+    ]
+
+    /// What a main-menu item must carry to answer this binding, or nil when the
+    /// chord cannot be a menu key equivalent — a pure-modifier chord types
+    /// nothing for AppKit to match, and an exotic key that neither the layout
+    /// nor the tables above can name has no representation either. Callers fall
+    /// back to the global tap in that case, which matches by key code and needs
+    /// no character at all.
+    var menuKeyEquivalent: (characters: String, modifiers: NSEvent.ModifierFlags)? {
+        guard let keyCode else { return nil }
+        if let scalarValue = Self.menuFunctionKeyScalars[keyCode],
+           let scalar = UnicodeScalar(UInt32(scalarValue)) {
+            return (String(Character(scalar)), modifiers)
+        }
+        if let control = Self.menuControlCharacters[keyCode] {
+            return (control, modifiers)
+        }
+        // Key equivalents are declared in lower case; the shift in a chord like
+        // ⌘⇧A lives in the modifier mask, not in the character.
+        // An unnameable key comes back as "Key 105", which is never one character.
+        let typed = KeyCodeResolver.label(forKeyCode: keyCode).lowercased()
+        guard typed.count == 1 else { return nil }
+        return (typed, modifiers)
+    }
+
     // MARK: - Key labels
 
     static let specialKeyLabels: [Int: String] = [

--- a/App/ttaccessible/Models/HotkeyBinding.swift
+++ b/App/ttaccessible/Models/HotkeyBinding.swift
@@ -128,6 +128,42 @@ struct HotkeyBinding: Codable, Equatable {
     /// no character at all.
     var menuKeyEquivalent: (characters: String, modifiers: NSEvent.ModifierFlags)? {
         guard let keyCode else { return nil }
+        return rawMenuKeyEquivalent(for: keyCode)
+    }
+
+    /// What may safely be installed on a main-menu item for this binding, or nil
+    /// when the item must carry no shortcut at all. A binding that types into a
+    /// focused field is withheld from the menu: an item carrying a bare
+    /// `keyEquivalent` answers it before the field sees it, so the mic would
+    /// toggle mid-sentence. The tap declines the same bindings while a field is
+    /// focused (`HotkeyMonitor.handleTapEvent`) — both halves have to withhold or
+    /// the problem just moves from one to the other.
+    var safeMenuKeyEquivalent: (characters: String, modifiers: NSEvent.ModifierFlags)? {
+        typesIntoTextFields ? nil : menuKeyEquivalent
+    }
+
+    /// True when pressing this binding with a text field focused would insert a
+    /// character. ⇧ is not protective — ⇧K still types "K"; only ⌘, ⌃ or ⌥ put a
+    /// chord out of reach of ordinary typing. F13–F20, arrows and Esc type
+    /// nothing, so they stay usable bare, which is the point of binding them.
+    var typesIntoTextFields: Bool {
+        guard modifiers.isDisjoint(with: [.command, .control, .option]) else { return false }
+        guard let scalar = menuKeyEquivalent?.characters.unicodeScalars.first else { return false }
+        return Self.isPrintable(scalar)
+    }
+
+    /// Whether a scalar would insert a visible character if left alone. Function
+    /// and navigation keys map into the F700–F8FF private-use range and type
+    /// nothing. The single rule behind both the menu half and the tap half, so
+    /// the two can't drift apart.
+    static func isPrintable(_ scalar: UnicodeScalar) -> Bool {
+        scalar.value >= 0x20 && scalar.value != 0x7F
+            && (scalar.value < 0xF700 || scalar.value > 0xF8FF)
+    }
+
+    private func rawMenuKeyEquivalent(
+        for keyCode: Int
+    ) -> (characters: String, modifiers: NSEvent.ModifierFlags)? {
         if let scalarValue = Self.menuFunctionKeyScalars[keyCode],
            let scalar = UnicodeScalar(UInt32(scalarValue)) {
             return (String(Character(scalar)), modifiers)

--- a/App/ttaccessible/Models/HotkeyBinding.swift
+++ b/App/ttaccessible/Models/HotkeyBinding.swift
@@ -142,20 +142,41 @@ struct HotkeyBinding: Codable, Equatable {
         typesIntoTextFields ? nil : menuKeyEquivalent
     }
 
-    /// True when pressing this binding with a text field focused would insert a
-    /// character. ⇧ is not protective — ⇧K still types "K"; only ⌘, ⌃ or ⌥ put a
-    /// chord out of reach of ordinary typing. F13–F20, arrows and Esc type
-    /// nothing, so they stay usable bare, which is the point of binding them.
+    /// Key codes a focused text field consumes even though they insert no
+    /// visible character: Return and Enter insert a newline or send, Tab moves
+    /// focus, Delete edits, and the arrows / Home / End / Page keys move the
+    /// caret. "Would the field use this key" is the real question — "is it
+    /// printable" only answers part of it.
+    ///
+    /// F1–F20 are deliberately absent. They do nothing in a text field, which is
+    /// exactly what makes them the one family safe to bind bare.
+    private static let textEditingKeyCodes: Set<Int> = [
+        36,   // Return
+        76,   // Enter
+        48,   // Tab
+        51,   // Delete
+        117,  // Forward Delete
+        123, 124, 125, 126,  // ← → ↓ ↑
+        115, 119,            // Home, End
+        116, 121             // Page Up, Page Down
+    ]
+
+    /// True when pressing this binding with a text field focused would type into
+    /// it or move around inside it. ⇧ is not protective — ⇧K still types "K", and
+    /// ⇧Tab still moves focus; only ⌘, ⌃ or ⌥ put a chord out of reach of
+    /// ordinary editing.
     var typesIntoTextFields: Bool {
         guard modifiers.isDisjoint(with: [.command, .control, .option]) else { return false }
+        guard let keyCode else { return false }  // a pure-modifier chord types nothing
+        if Self.textEditingKeyCodes.contains(keyCode) { return true }
         guard let scalar = menuKeyEquivalent?.characters.unicodeScalars.first else { return false }
         return Self.isPrintable(scalar)
     }
 
     /// Whether a scalar would insert a visible character if left alone. Function
     /// and navigation keys map into the F700–F8FF private-use range and type
-    /// nothing. The single rule behind both the menu half and the tap half, so
-    /// the two can't drift apart.
+    /// nothing; the navigation half of that range is caught by
+    /// `textEditingKeyCodes` above instead.
     static func isPrintable(_ scalar: UnicodeScalar) -> Bool {
         scalar.value >= 0x20 && scalar.value != 0x7F
             && (scalar.value < 0xF700 || scalar.value > 0xF8FF)

--- a/App/ttaccessible/Services/HotkeyMonitor.swift
+++ b/App/ttaccessible/Services/HotkeyMonitor.swift
@@ -240,9 +240,10 @@ final class HotkeyMonitor {
         switch event.type {
         case .keyDown:
             guard Int(event.keyCode) == binding.keyCode, mods == binding.modifiers else { return false }
-            // A bare printable key (no modifiers) must keep typing into a
-            // focused text field — the field wins over push-to-talk there.
-            if binding.modifiers.isEmpty, Self.isPrintable(event), Self.isTextInputFocused() {
+            // A binding the focused field would use — a printable key, Return,
+            // Tab, an arrow — must keep reaching it: the field wins over
+            // push-to-talk there. Same predicate as the global tap and the menu.
+            if binding.typesIntoTextFields, Self.isTextInputFocused() {
                 return false
             }
             if event.isARepeat == false { setPressed(true) }
@@ -256,15 +257,6 @@ final class HotkeyMonitor {
         default:
             return false
         }
-    }
-
-    /// Whether the event would insert a visible character if left alone
-    /// (excludes function/navigation keys, which map into the F700 range).
-    /// Shares `HotkeyBinding.isPrintable` with the global path and the menu, so
-    /// all three agree on which keys a focused field gets to keep.
-    private static func isPrintable(_ event: NSEvent) -> Bool {
-        guard let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first else { return false }
-        return HotkeyBinding.isPrintable(scalar)
     }
 
     private static func isTextInputFocused() -> Bool {

--- a/App/ttaccessible/Services/HotkeyMonitor.swift
+++ b/App/ttaccessible/Services/HotkeyMonitor.swift
@@ -49,9 +49,12 @@ final class HotkeyMonitor {
 
     private var binding: HotkeyBinding?
     private var scope: Scope = .local
-    /// When true, the global tap ignores events while the app is frontmost — used
-    /// for the mute chord, whose focused case is handled by the menu shortcut.
-    private var globalOnlyWhenInactive = false
+    /// When true, the global tap defers to the main menu while the app is
+    /// frontmost — but only for a chord the menu actually carries. A menu key
+    /// equivalent is delivered to the focused app whatever the (listen-only) tap
+    /// does, so acting on it here too would double-fire; a chord no menu item
+    /// owns has no other handler, so the tap stays the one that answers it.
+    private var deferToMainMenuWhenActive = false
     private var wantsReleaseEvents = true
 
     private var localMonitor: Any?
@@ -67,13 +70,13 @@ final class HotkeyMonitor {
     func configure(
         binding: HotkeyBinding?,
         scope: Scope,
-        globalOnlyWhenInactive: Bool = false,
+        deferToMainMenuWhenActive: Bool = false,
         wantsReleaseEvents: Bool = true
     ) {
         stop()
         self.binding = binding
         self.scope = scope
-        self.globalOnlyWhenInactive = globalOnlyWhenInactive
+        self.deferToMainMenuWhenActive = deferToMainMenuWhenActive
         self.wantsReleaseEvents = wantsReleaseEvents
 
         guard let binding, binding.isValid else { return }
@@ -166,16 +169,18 @@ final class HotkeyMonitor {
             return
         }
         guard let binding else { return }
-        // The inactive-only guard (mute chord: the in-app menu shortcut owns
-        // the focused case) suppresses PRESSES only. Releases always run —
+        // The defer-to-menu guard suppresses PRESSES only. Releases always run —
         // if the app becomes active between down and up, eating the keyUp
         // would leave isPressed stuck and silently swallow the next toggle.
-        let suppressPress = globalOnlyWhenInactive && NSApp.isActive
+        // Evaluated only once the chord has already matched, so the menu walk
+        // never runs on ordinary typing.
+        let menuOwnsPress = { self.deferToMainMenuWhenActive && NSApp.isActive && Self.mainMenuOwns(event) }
 
         let mods = Self.modifierFlags(from: event.flags)
         if binding.isModifierOnly {
             let chordActive = mods == binding.modifiers
-            if chordActive, suppressPress { return }
+            // A pure-modifier chord can't be a menu key equivalent, so the menu
+            // never owns it and there is nothing to defer to.
             setPressed(chordActive)
             return
         }
@@ -183,7 +188,7 @@ final class HotkeyMonitor {
         switch type {
         case .keyDown:
             let autorepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
-            guard keyCode == binding.keyCode, mods == binding.modifiers, suppressPress == false else { return }
+            guard keyCode == binding.keyCode, mods == binding.modifiers, menuOwnsPress() == false else { return }
             if autorepeat == false { setPressed(true) }
         case .keyUp:
             guard keyCode == binding.keyCode else { return }
@@ -287,5 +292,45 @@ final class HotkeyMonitor {
         if cg.contains(.maskAlternate) { flags.insert(.option) }
         if cg.contains(.maskShift) { flags.insert(.shift) }
         return flags
+    }
+
+    /// True when a main-menu item carries this exact key equivalent. AppKit
+    /// delivers it to the focused app regardless of our listen-only tap, so the
+    /// menu is the handler and the tap must not act on top of it. Compares what
+    /// AppKit itself compares — `charactersIgnoringModifiers` against
+    /// `keyEquivalent` — so letters, punctuation and F-keys all match by the
+    /// same rule.
+    private static func mainMenuOwns(_ event: CGEvent) -> Bool {
+        guard let mainMenu = NSApp.mainMenu,
+              let nsEvent = NSEvent(cgEvent: event),
+              let characters = nsEvent.charactersIgnoringModifiers?.lowercased(),
+              characters.isEmpty == false else { return false }
+        return menu(mainMenu, carries: characters, modifiers: comparableModifiers(nsEvent.modifierFlags))
+    }
+
+    /// Menu key equivalents are declared without the layout/hardware-only flags,
+    /// so both sides are reduced to the same set before comparing.
+    static func comparableModifiers(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        flags.intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .numericPad, .function])
+    }
+
+    static func menu(
+        _ menu: NSMenu,
+        carries characters: String,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Bool {
+        for item in menu.items {
+            if item.keyEquivalent.isEmpty == false,
+               item.keyEquivalent.lowercased() == characters,
+               comparableModifiers(item.keyEquivalentModifierMask) == modifiers {
+                return true
+            }
+            if let submenu = item.submenu,
+               self.menu(submenu, carries: characters, modifiers: modifiers) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/App/ttaccessible/Services/HotkeyMonitor.swift
+++ b/App/ttaccessible/Services/HotkeyMonitor.swift
@@ -189,6 +189,13 @@ final class HotkeyMonitor {
         case .keyDown:
             let autorepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
             guard keyCode == binding.keyCode, mods == binding.modifiers, menuOwnsPress() == false else { return }
+            // A binding that types must keep typing into our own focused field —
+            // the field wins over the mic toggle there, exactly as it does on the
+            // local path. Only checked while WE are frontmost: the whole point of
+            // a global binding is to act in other apps, whatever has focus there.
+            // Evaluated after the chord matched, so ordinary typing never pays
+            // for the layout lookup.
+            if NSApp.isActive, binding.typesIntoTextFields, Self.isTextInputFocused() { return }
             if autorepeat == false { setPressed(true) }
         case .keyUp:
             guard keyCode == binding.keyCode else { return }
@@ -253,10 +260,11 @@ final class HotkeyMonitor {
 
     /// Whether the event would insert a visible character if left alone
     /// (excludes function/navigation keys, which map into the F700 range).
+    /// Shares `HotkeyBinding.isPrintable` with the global path and the menu, so
+    /// all three agree on which keys a focused field gets to keep.
     private static func isPrintable(_ event: NSEvent) -> Bool {
         guard let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first else { return false }
-        return scalar.value >= 0x20 && scalar.value != 0x7F
-            && (scalar.value < 0xF700 || scalar.value > 0xF8FF)
+        return HotkeyBinding.isPrintable(scalar)
     }
 
     private static func isTextInputFocused() -> Bool {
@@ -301,7 +309,13 @@ final class HotkeyMonitor {
     /// `keyEquivalent` — so letters, punctuation and F-keys all match by the
     /// same rule.
     private static func mainMenuOwns(_ event: CGEvent) -> Bool {
-        guard let mainMenu = NSApp.mainMenu,
+        // The main menu is inert for the duration of a modal session, so an item
+        // carrying the chord will never answer it — deferring would leave the mic
+        // toggle dead while an alert is up, which is when cutting your mic matters
+        // most. (`isEnabled` is not the test to use instead: with an auto-enabling
+        // menu it is only refreshed when the menu is actually displayed.)
+        guard NSApp.modalWindow == nil,
+              let mainMenu = NSApp.mainMenu,
               let nsEvent = NSEvent(cgEvent: event),
               let characters = nsEvent.charactersIgnoringModifiers?.lowercased(),
               characters.isEmpty == false else { return false }

--- a/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
+++ b/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
@@ -174,8 +174,38 @@ final class HotkeyMenuOwnershipTests: XCTestCase {
         XCTAssertFalse(binding(96, [], "F5").typesIntoTextFields)
     }
 
-    func testBareArrowKeyIsNotTyping() {
-        XCTAssertFalse(binding(126, [], "\u{2191}").typesIntoTextFields)
+    func testReturnAndEnterAreTyping() {
+        // Return in the chat field sends the message; bound bare it was toggling
+        // the mic instead. It types nothing, so the printable rule alone missed
+        // it — the field still consumes it.
+        XCTAssertTrue(binding(36, [], "Return").typesIntoTextFields)
+        XCTAssertTrue(binding(76, [], "Enter").typesIntoTextFields)
+    }
+
+    func testTabAndDeleteAreTyping() {
+        // The recorder only reserves these when pressed with NO modifier, so the
+        // ⇧ variants are bindable and would otherwise steal focus movement and
+        // backspace out of a focused field.
+        XCTAssertTrue(binding(48, [.shift], "Tab").typesIntoTextFields)
+        XCTAssertTrue(binding(51, [.shift], "Delete").typesIntoTextFields)
+        XCTAssertTrue(binding(117, [], "Fwd Delete").typesIntoTextFields)
+    }
+
+    func testCaretMovementKeysAreTyping() {
+        // Arrows and the Home/End/Page family move the caret — a field in use
+        // needs them as much as it needs letters.
+        for keyCode in [123, 124, 125, 126, 115, 119, 116, 121] {
+            XCTAssertTrue(binding(keyCode, [], "key").typesIntoTextFields,
+                          "keyCode \(keyCode) must yield to a focused field")
+        }
+    }
+
+    func testEditingKeysWithACommandChordAreNotTyping() {
+        // ⌘Return / ⌥↑ are out of reach of ordinary editing, so they stay
+        // available as bindings and keep their menu shortcut.
+        XCTAssertFalse(binding(36, [.command], "Return").typesIntoTextFields)
+        XCTAssertFalse(binding(126, [.option], "\u{2191}").typesIntoTextFields)
+        XCTAssertNotNil(binding(36, [.command], "Return").safeMenuKeyEquivalent)
     }
 
     func testModifierOnlyChordIsNotTyping() {
@@ -210,9 +240,10 @@ final class HotkeyMenuOwnershipTests: XCTestCase {
         XCTAssertFalse(HotkeyMonitor.menu(menu, carries: "m", modifiers: []))
     }
 
-    func testPrintabilityRuleMatchesTheLocalPath() {
-        // One rule behind the menu, the tap and the local monitor. If these
-        // diverge, a key is swallowed on one path and typed on another.
+    func testPrintabilityCoversTheCharacterHalfOfTheRule() {
+        // `typesIntoTextFields` is the one predicate the menu, the tap and the
+        // local monitor all consult; this is the character half of it. The keys
+        // that type nothing but a field still uses are covered by key code above.
         XCTAssertTrue(HotkeyBinding.isPrintable(UnicodeScalar("m")))
         XCTAssertTrue(HotkeyBinding.isPrintable(UnicodeScalar(" ")))
         XCTAssertFalse(HotkeyBinding.isPrintable(UnicodeScalar(UInt32(NSF13FunctionKey))!))

--- a/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
+++ b/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
@@ -99,10 +99,19 @@ final class HotkeyMenuOwnershipTests: XCTestCase {
         XCTAssertNil(binding.menuKeyEquivalent)
     }
 
+    func testF13IsNamedAndHasAMenuKeyEquivalent() {
+        // F13–F19 are the one safe global binding (they type nothing), so they
+        // have to be nameable in the recorder and usable as a menu shortcut.
+        XCTAssertEqual(KeyCodeResolver.label(forKeyCode: 105), "F13")
+        let binding = HotkeyBinding(keyCode: 105, modifiers: [], keyLabel: "F13")
+        XCTAssertEqual(binding.menuKeyEquivalent?.characters,
+                       String(UnicodeScalar(UInt32(NSF13FunctionKey))!))
+    }
+
     func testUnnameableKeyHasNoMenuKeyEquivalent() {
-        // keyCode 105 is F13, which the label tables don't name and no layout
-        // types — it must degrade to "the tap handles it", not to a bogus title.
-        let binding = HotkeyBinding(keyCode: 105, modifiers: [.command], keyLabel: nil)
+        // A key no table names and no layout types must degrade to "the tap
+        // handles it", not to a bogus menu title.
+        let binding = HotkeyBinding(keyCode: 200, modifiers: [.command], keyLabel: nil)
         XCTAssertNil(binding.menuKeyEquivalent)
     }
 

--- a/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
+++ b/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
@@ -136,6 +136,90 @@ final class HotkeyMenuOwnershipTests: XCTestCase {
                                          modifiers: equivalent.modifiers))
     }
 
+    // MARK: - Bindings that type must not steal the keystroke
+
+    private func binding(_ keyCode: Int, _ mods: NSEvent.ModifierFlags, _ label: String) -> HotkeyBinding {
+        HotkeyBinding(keyCode: keyCode, modifiers: mods, keyLabel: label)
+    }
+
+    func testBarePrintableKeyIsRecognisedAsTyping() {
+        // keyCode 46 is M on ANSI. Bound bare, it has to keep typing into the
+        // chat field instead of toggling the mic mid-sentence.
+        XCTAssertTrue(binding(46, [], "M").typesIntoTextFields)
+    }
+
+    func testShiftAloneDoesNotProtectABinding() {
+        // ⇧M still types "M" — shift is part of the character, not an escape
+        // from the keyboard.
+        XCTAssertTrue(binding(46, [.shift], "M").typesIntoTextFields)
+    }
+
+    func testCommandControlOrOptionMakeABindingNonTyping() {
+        // Each of the three on its own puts the chord out of reach of typing.
+        XCTAssertFalse(binding(46, [.command], "M").typesIntoTextFields)
+        XCTAssertFalse(binding(46, [.control], "M").typesIntoTextFields)
+        XCTAssertFalse(binding(46, [.option], "M").typesIntoTextFields)
+    }
+
+    func testBareSpaceIsTyping() {
+        // Space is the example the model's own header offers, and it is the one
+        // most likely to be bound bare.
+        XCTAssertTrue(binding(49, [], "Space").typesIntoTextFields)
+    }
+
+    func testBareFunctionKeysAreNotTyping() {
+        // F13–F20 type nothing and carry no system function — staying bindable
+        // bare is the entire reason commit 3 named them.
+        XCTAssertFalse(binding(105, [], "F13").typesIntoTextFields)
+        XCTAssertFalse(binding(96, [], "F5").typesIntoTextFields)
+    }
+
+    func testBareArrowKeyIsNotTyping() {
+        XCTAssertFalse(binding(126, [], "\u{2191}").typesIntoTextFields)
+    }
+
+    func testModifierOnlyChordIsNotTyping() {
+        XCTAssertFalse(HotkeyBinding(keyCode: nil, modifiers: [.command, .control], keyLabel: nil)
+            .typesIntoTextFields)
+    }
+
+    func testTypingBindingIsWithheldFromTheMenu() {
+        // The menu half: no key equivalent is installed at all, so AppKit never
+        // answers the key ahead of the focused field.
+        XCTAssertNil(binding(46, [], "M").safeMenuKeyEquivalent)
+        XCTAssertNil(binding(49, [], "Space").safeMenuKeyEquivalent)
+    }
+
+    func testNonTypingBindingStillReachesTheMenu() {
+        // Withholding must not cost the safe bindings their menu shortcut —
+        // that shortcut is what makes one chord work while the app is focused.
+        XCTAssertEqual(binding(46, [.command, .option], "M").safeMenuKeyEquivalent?.characters, "m")
+        XCTAssertEqual(binding(105, [], "F13").safeMenuKeyEquivalent?.characters,
+                       String(UnicodeScalar(UInt32(NSF13FunctionKey))!))
+    }
+
+    func testWithheldBindingIsAlsoNotOwnedByTheMenu() {
+        // The two halves have to agree in this direction too: since nothing is
+        // installed, the ownership check must report the chord as unowned, which
+        // is what routes it to the tap — where the focused-field guard then
+        // declines it. Both withhold; neither acts while typing.
+        let typing = binding(46, [], "M")
+        XCTAssertNil(typing.safeMenuKeyEquivalent)
+        let menu = NSMenu()
+        menu.addItem(withTitle: "Microphone", action: nil, keyEquivalent: "")
+        XCTAssertFalse(HotkeyMonitor.menu(menu, carries: "m", modifiers: []))
+    }
+
+    func testPrintabilityRuleMatchesTheLocalPath() {
+        // One rule behind the menu, the tap and the local monitor. If these
+        // diverge, a key is swallowed on one path and typed on another.
+        XCTAssertTrue(HotkeyBinding.isPrintable(UnicodeScalar("m")))
+        XCTAssertTrue(HotkeyBinding.isPrintable(UnicodeScalar(" ")))
+        XCTAssertFalse(HotkeyBinding.isPrintable(UnicodeScalar(UInt32(NSF13FunctionKey))!))
+        XCTAssertFalse(HotkeyBinding.isPrintable(UnicodeScalar(UInt32(NSUpArrowFunctionKey))!))
+        XCTAssertFalse(HotkeyBinding.isPrintable(UnicodeScalar(0x7F)))
+    }
+
     func testComparableModifiersDropsHardwareOnlyFlags() {
         // An F-key press carries .function and a keypad key .numericPad, neither
         // of which a menu declares — left in, nothing would ever match.

--- a/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
+++ b/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
@@ -74,6 +74,59 @@ final class HotkeyMenuOwnershipTests: XCTestCase {
         XCTAssertFalse(HotkeyMonitor.menu(makeMenu(), carries: "z", modifiers: [.command, .control]))
     }
 
+    // MARK: - Binding -> menu key equivalent
+
+    func testLetterBindingBecomesALowercaseKeyEquivalent() {
+        // The shift in ⌘⇧A belongs in the modifier mask, not in the character —
+        // an uppercase "A" would need ⇧ declared twice and match nothing.
+        let binding = HotkeyBinding.defaultMuteHotkey()
+        let equivalent = binding.menuKeyEquivalent
+        XCTAssertEqual(equivalent?.characters, "a")
+        XCTAssertEqual(equivalent?.modifiers, [.command, .shift])
+    }
+
+    func testFunctionKeyBindingBecomesItsUnicodeScalar() {
+        // keyCode 96 is F5; AppKit expects the scalar, not the string "F5".
+        let binding = HotkeyBinding(keyCode: 96, modifiers: [], keyLabel: "F5")
+        XCTAssertEqual(binding.menuKeyEquivalent?.characters,
+                       String(UnicodeScalar(UInt32(NSF5FunctionKey))!))
+    }
+
+    func testModifierOnlyChordHasNoMenuKeyEquivalent() {
+        // Nothing is typed, so no menu item can carry it — the tap owns it in
+        // every focus state instead.
+        let binding = HotkeyBinding(keyCode: nil, modifiers: [.command, .control], keyLabel: nil)
+        XCTAssertNil(binding.menuKeyEquivalent)
+    }
+
+    func testUnnameableKeyHasNoMenuKeyEquivalent() {
+        // keyCode 105 is F13, which the label tables don't name and no layout
+        // types — it must degrade to "the tap handles it", not to a bogus title.
+        let binding = HotkeyBinding(keyCode: 105, modifiers: [.command], keyLabel: nil)
+        XCTAssertNil(binding.menuKeyEquivalent)
+    }
+
+    func testSpaceBindingBecomesASpaceCharacter() {
+        let binding = HotkeyBinding(keyCode: 49, modifiers: [.option], keyLabel: "Space")
+        XCTAssertEqual(binding.menuKeyEquivalent?.characters, " ")
+        XCTAssertEqual(binding.menuKeyEquivalent?.modifiers, [.option])
+    }
+
+    func testMenuEquivalentRoundTripsThroughTheOwnershipCheck() {
+        // The two halves have to agree: whatever we put on the item must be what
+        // the tap then recognises as menu-owned, or the chord fires twice.
+        let binding = HotkeyBinding(keyCode: 46, modifiers: [.command, .option], keyLabel: "M")
+        guard let equivalent = binding.menuKeyEquivalent else {
+            return XCTFail("⌥⌘M must have a menu key equivalent")
+        }
+        let menu = NSMenu()
+        menu.addItem(withTitle: "Microphone", action: nil, keyEquivalent: equivalent.characters)
+            .keyEquivalentModifierMask = equivalent.modifiers
+        XCTAssertTrue(HotkeyMonitor.menu(menu,
+                                         carries: equivalent.characters.lowercased(),
+                                         modifiers: equivalent.modifiers))
+    }
+
     func testComparableModifiersDropsHardwareOnlyFlags() {
         // An F-key press carries .function and a keypad key .numericPad, neither
         // of which a menu declares — left in, nothing would ever match.

--- a/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
+++ b/App/ttaccessibleTests/HotkeyMenuOwnershipTests.swift
@@ -1,0 +1,83 @@
+//
+//  HotkeyMenuOwnershipTests.swift
+//  ttaccessibleTests
+//
+//  The global mute tap defers to the main menu only for a chord the menu
+//  actually carries. Getting that predicate wrong is invisible in a build and
+//  fails in opposite directions — too eager and a rebound hotkey does nothing
+//  while the app is focused, too lax and a binding that collides with an in-app
+//  shortcut fires both actions at once.
+//
+//  Menu construction only; no window, no run loop.
+//
+
+import XCTest
+import AppKit
+@testable import ttaccessible
+
+final class HotkeyMenuOwnershipTests: XCTestCase {
+
+    /// Mirrors the real shape: shortcuts live on items inside submenus.
+    private func makeMenu() -> NSMenu {
+        let root = NSMenu()
+
+        let userItem = NSMenuItem()
+        let userMenu = NSMenu(title: "User")
+        userMenu.addItem(withTitle: "Microphone", action: nil, keyEquivalent: "a")
+            .keyEquivalentModifierMask = [.command, .shift]
+        userMenu.addItem(withTitle: "Master mute", action: nil, keyEquivalent: "m")
+            .keyEquivalentModifierMask = [.command]
+        userItem.submenu = userMenu
+        root.addItem(userItem)
+
+        let windowItem = NSMenuItem()
+        let windowMenu = NSMenu(title: "Window")
+        windowMenu.addItem(withTitle: "Mixer", action: nil,
+                           keyEquivalent: String(UnicodeScalar(UInt32(NSF5FunctionKey))!))
+            .keyEquivalentModifierMask = []
+        windowMenu.addItem(withTitle: "No shortcut", action: nil, keyEquivalent: "")
+        windowItem.submenu = windowMenu
+        root.addItem(windowItem)
+
+        return root
+    }
+
+    func testDefaultMuteChordIsOwnedByTheMenu() {
+        // ⌘⇧A must keep going to the menu item — the tap acting on it too would
+        // toggle the mic twice.
+        XCTAssertTrue(HotkeyMonitor.menu(makeMenu(), carries: "a", modifiers: [.command, .shift]))
+    }
+
+    func testRe_boundChordIsNotOwnedByTheMenu() {
+        // ⌥⌘M matches nothing, so the tap is the only handler and must act.
+        XCTAssertFalse(HotkeyMonitor.menu(makeMenu(), carries: "m", modifiers: [.command, .option]))
+    }
+
+    func testSameKeyDifferentModifiersIsNotOwned() {
+        XCTAssertFalse(HotkeyMonitor.menu(makeMenu(), carries: "a", modifiers: [.command]))
+    }
+
+    func testCollidingChordInAnotherSubmenuIsOwned() {
+        // ⌘M already opens/closes a window — a mute binding on it must defer,
+        // not fire both actions.
+        XCTAssertTrue(HotkeyMonitor.menu(makeMenu(), carries: "m", modifiers: [.command]))
+    }
+
+    func testFunctionKeyEquivalentIsMatched() {
+        // F13–F19 are the recommended global bindings, so F-keys must compare
+        // by the same rule as letters rather than silently never matching.
+        let f5 = String(UnicodeScalar(UInt32(NSF5FunctionKey))!)
+        XCTAssertTrue(HotkeyMonitor.menu(makeMenu(), carries: f5, modifiers: []))
+    }
+
+    func testUnboundKeyIsNotOwned() {
+        XCTAssertFalse(HotkeyMonitor.menu(makeMenu(), carries: "z", modifiers: [.command, .control]))
+    }
+
+    func testComparableModifiersDropsHardwareOnlyFlags() {
+        // An F-key press carries .function and a keypad key .numericPad, neither
+        // of which a menu declares — left in, nothing would ever match.
+        let raw: NSEvent.ModifierFlags = [.command, .shift, .function, .capsLock, .numericPad]
+        XCTAssertEqual(HotkeyMonitor.comparableModifiers(raw), [.command, .shift])
+    }
+}


### PR DESCRIPTION
The global mic-toggle hotkey became configurable in #31, but the focused case never followed it. `AppDelegate` installed the tap with `globalOnlyWhenInactive: true` — suppressing every press while ttaccessible was frontmost, on the assumption that "the menu shortcut covers the focused case" — while the User ▸ Microphone item stayed hardcoded at `.keyboardShortcut("a", modifiers: [.command, .shift])`. So once a user changed the binding, which is the whole point of it being configurable, nothing answered it with the app in front: the tap suppressed it and no menu item matched it. ⌘⇧A meanwhile kept working, which makes it read as random rather than broken.

Three commits.

**1. Defer to the menu only for a chord the menu actually carries.** A menu key equivalent reaches the focused app whatever a listen-only tap does, so acting on it as well would double-fire — but a chord no menu item owns has no other handler, and the tap should answer it. `mainMenuOwns(event)` compares what AppKit itself compares, `charactersIgnoringModifiers` against `keyEquivalent` with the hardware-only flags stripped, so letters, punctuation and F-keys follow one rule. It runs only after the chord has already matched, so ordinary typing never walks the menu.

Behaviour is unchanged where it already worked: ⌘⇧A focused still goes to the menu item, and a binding that collides with an existing in-app shortcut (⌘E, F5…) still fires only that shortcut. A pure-modifier chord can never be a menu key equivalent, so it no longer waits on a menu item that cannot exist.

Also requires a channel, matching the menu item's own disabled state — without it `activateVoiceTransmission` fails with `notInChannel` and pops an alert over whatever app the user is actually in.

**2. One chord everywhere once the hotkey is global.** The menu item now carries the configured binding, applied at the AppKit layer on the same re-apply cycle as the User menu's visibility (SwiftUI rebuilds the main menu and would restore its declared shortcut). ⌘⇧A remains the default and stays put while the hotkey is app-local only. `HotkeyBinding.menuKeyEquivalent` returns nil for a chord with no key-equivalent form, in which case the item gets no shortcut rather than being stranded on ⌘⇧A, and the tap owns that binding in every focus state.

**3. Name F13–F20.** They type nothing and carry no system function, which is what makes them the safe choice for a global binding — but the label table stopped at F12, so binding one showed as "Key 105" in the recorder and could not become a menu key equivalent either. The keys worth recommending were the keys the UI could not name.

Cut from current `main` (1.10.0). Builds clean; the suite passes with 7 new tests covering the ownership predicate in both directions and the binding → key-equivalent mapping, including the round trip between the two halves — they have to agree or the chord fires twice or not at all.

Note: this touches `HotkeyMonitor.handleTapEvent`, so it overlaps #34 textually. #34's version needs one extra term (`installedConsuming == false`), because a consuming tap swallows the chord before AppKit can route it to the menu and deferring would drop the press. Whichever lands second is a small resolution either way.
